### PR TITLE
docs: update CLAUDE.md with accurate tool count and release checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ This is an enhanced Model Context Protocol (MCP) server that provides AI assista
 ### Core Architecture
 
 **MCP Server Entry Point**: `src/server.ts`
-- Registers 24 tools for OmniFocus operations
+- Registers 29 tools for OmniFocus operations
 - Uses `@modelcontextprotocol/sdk` for MCP protocol handling
 - Supports both individual and batch operations (with true batching for 9-12x performance)
 
@@ -59,16 +59,17 @@ This is an enhanced Model Context Protocol (MCP) server that provides AI assista
 
 ### Tool Categories
 
-1. **Task Management**: `add_omnifocus_task`, `edit_item`, `remove_item`, `get_task_by_id`
-2. **Project Management**: `add_project`, `list_projects`, `get_project_by_id`
+1. **Task Management**: `add_omnifocus_task`, `edit_item`, `remove_item`, `get_task_by_id`, `search_tasks`
+2. **Project Management**: `add_project`, `list_projects`, `get_project_by_id`, `duplicate_project`
 3. **Folder Management**: `add_folder`, `get_folder_by_id`
-4. **Batch Operations**: `batch_add_items`, `batch_edit_items`, `batch_remove_items` (true batching - 9-12x faster)
-5. **Built-in Perspectives**: `get_inbox_tasks`, `get_flagged_tasks`, `get_forecast_tasks`, `get_tasks_by_tag`
-6. **Advanced Filtering**: `filter_tasks` (most powerful filtering engine)
-7. **Custom Perspectives**: `list_custom_perspectives`, `get_custom_perspective_tasks`
-8. **Review Workflow**: `get_projects_for_review`, `batch_mark_reviewed`
-9. **Analytics**: `get_today_completed_tasks`
-10. **Utility**: `get_server_version`
+4. **Tag Management**: `list_tags`, `edit_tag`
+5. **Batch Operations**: `batch_add_items`, `batch_edit_items`, `batch_remove_items`, `batch_filter_tasks` (true batching - 9-12x faster)
+6. **Built-in Perspectives**: `get_inbox_tasks`, `get_flagged_tasks`, `get_forecast_tasks`, `get_tasks_by_tag`
+7. **Advanced Filtering**: `filter_tasks` (most powerful filtering engine)
+8. **Custom Perspectives**: `list_custom_perspectives`, `get_custom_perspective_tasks`
+9. **Review Workflow**: `get_projects_for_review`, `batch_mark_reviewed`
+10. **Analytics**: `get_today_completed_tasks`
+11. **Utility**: `get_server_version`, `diagnose_connection`
 
 ## Development Notes
 
@@ -119,6 +120,7 @@ app.evaluateJavascript(`(() => {
 **Version Management**:
 - **IMPORTANT**: Bump the version in `package.json` every time code changes are made
 - **IMPORTANT**: Update `README.md` when adding new tools or features
+- **IMPORTANT**: Update `docs/WHATS_NEW.md` with user-facing changes (this document helps AI assistants understand new capabilities)
 - The version in `src/server.ts` is read automatically from `package.json` (single source of truth)
 - Use semantic versioning: patch (x.x.X) for fixes, minor (x.X.0) for new features, major (X.0.0) for breaking changes
 - The `get_server_version` tool allows verifying which version is running in a Claude session


### PR DESCRIPTION
## Summary
- Update tool count from 24 to 29 tools
- Add new Sprint 4-8 tools to appropriate categories
- Add reminder to update docs/WHATS_NEW.md on releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)