### PR TITLE
docs: add Sprint 9 plan for tag operations & query improvements

### DIFF
--- a/docs/SPRINT_PROGRESS.md
+++ b/docs/SPRINT_PROGRESS.md
@@ -2,7 +2,7 @@
 
 > **Last Updated**: January 8, 2026
 > **Branch**: `main`
-> **Current Version**: 1.23.0
+> **Current Version**: 1.23.1
 
 ## Completed Sprints
 
@@ -135,5 +135,74 @@ All feature request issues have been created:
 ## Reference Documents
 
 - **Full Review**: `docs/CODEBASE_REVIEW.md` - Complete 57-issue analysis
-- **Feature Roadmap**: `docs/feature-requests/README.md` - Prioritized feature requests
-- **GitHub Issues**: #5-#17 created with detailed descriptions
+- **Feature Roadmap**: `docs/archive/sprint-specs/README.md` - Implemented feature specs
+- **GitHub Issues**: #5-#28 created with detailed descriptions
+
+---
+
+## Next: Bug Fixes & Enhancements
+
+### Sprint 9: Tag Operations & Query Improvements
+
+Based on open issues in `docs/issues/`, Sprint 9 addresses critical tag bugs and query enhancements.
+
+#### Issue Analysis
+
+| ID | Issue | Type | Severity | Root Cause |
+|----|-------|------|----------|------------|
+| A | Tag operations silent failure | BUG | HIGH | Under investigation |
+| B | Project tag edit requires `itemType: "task"` | BUG | HIGH | `if (itemType === 'task')` guards skip projects |
+| C | get_tasks_by_tag ignores dropped tags | BUG | MEDIUM | `flattenedTags.filter(tag => tag.active)` |
+| D | Task IDs missing from perspective output | FEAT | MEDIUM | Not included in formatters |
+| E | No way to filter untagged tasks | FEAT | LOW | Missing parameter |
+| F | `inInbox` filter returns wrong results | BUG | MEDIUM | Logic issue |
+| G | False "moved to folder" success message | BUG | LOW | Missing "already in folder" check |
+
+#### Sprint 9A: Tag Operations (Critical)
+
+| Item | Issue | File | Effort |
+|------|-------|------|--------|
+| B | Fix project tag editing | `batchEditItems.js`, `editTask.js` | Low |
+| A | Verify tag operations work after B | Testing | Low |
+
+**Root cause for B**: Lines 251, 263, 271 in `batchEditItems.js` have `if (itemType === 'task')` guards that skip tag operations for projects.
+
+#### Sprint 9B: Query Improvements
+
+| Item | Issue | File | Effort |
+|------|-------|------|--------|
+| C | Add `includeDropped` param to get_tasks_by_tag | `tasksByTag.js` | Low |
+| D | Add task IDs to perspective tool output | Multiple formatters | Medium |
+
+**Root cause for C**: Line 42 in `tasksByTag.js` filters `flattenedTags.filter(tag => tag.active)`.
+
+#### Sprint 9C: Filter Enhancements
+
+| Item | Issue | File | Effort |
+|------|-------|------|--------|
+| E | Add `untagged: true` param to filter_tasks | `filterTasks.js` | Low |
+| F | Fix inInbox filter logic | `filterTasks.js` | Medium |
+
+#### Sprint 9D: Polish
+
+| Item | Issue | File | Effort |
+|------|-------|------|--------|
+| G | Add "already in folder" check | `editTask.js` | Low |
+
+#### Dependencies
+
+```
+A ←── B (same code area, fix B first to see if A resolves)
+D includes fix for get_inbox_tasks missing IDs
+C, E, F, G are independent
+```
+
+#### Source Issues
+
+- `docs/issues/bugs/2026-01-06-batch-edit-tags-silent-failure.md` (A)
+- `docs/issues/bugs/2026-01-08-project-tag-edit-requires-task-itemtype.md` (B)
+- `docs/issues/bugs/bug-get-tasks-by-tag-dropped-tags.md` (C)
+- `docs/issues/features/feature-request-perspective-task-ids.md` (D)
+- `docs/issues/features/2026-01-08-untagged-tasks-filter.md` (E)
+- `docs/issues/bugs/mcp-omnifocus-bug-report.md` (F, plus overlap with D)
+- `docs/issues/bugs/mcp-omnifocus-bug-false-move-success.md` (G)

--- a/docs/issues/bugs/2026-01-08-project-tag-edit-requires-task-itemtype.md
+++ b/docs/issues/bugs/2026-01-08-project-tag-edit-requires-task-itemtype.md
@@ -1,0 +1,59 @@
+# Bug: Editing project tags requires itemType "task" instead of "project"
+
+**Date discovered:** 2026-01-08
+**MCP version:** 1.23.1
+**Tool affected:** `batch_edit_items` (and likely `edit_item`)
+
+## Summary
+
+When attempting to add or remove tags from a project using `batch_edit_items` with `itemType: "project"`, the operation silently succeeds but no tags are actually modified. Using `itemType: "task"` for the same project ID works correctly.
+
+## Steps to Reproduce
+
+1. Get a project ID (e.g., via `list_projects`)
+2. Call `batch_edit_items` with:
+   ```json
+   {
+     "edits": [{
+       "id": "<project-id>",
+       "itemType": "project",
+       "removeTags": ["some-tag"]
+     }]
+   }
+   ```
+3. Observe: Tool returns success, but tag remains on the project
+
+4. Call the same operation with `itemType: "task"`:
+   ```json
+   {
+     "edits": [{
+       "id": "<project-id>",
+       "itemType": "task",
+       "removeTags": ["some-tag"]
+     }]
+   }
+   ```
+5. Observe: Tag is successfully removed
+
+## Expected Behavior
+
+Using `itemType: "project"` with a project ID should correctly modify the project's tags.
+
+## Actual Behavior
+
+- `itemType: "project"` + project ID = silent failure (reports success, no change)
+- `itemType: "task"` + project ID = works correctly (but semantically incorrect)
+
+## Context
+
+Discovered while removing the "area" tag from 6 projects. Initial attempts with `itemType: "project"` appeared successful but tags remained. Switching to `itemType: "task"` resolved the issue.
+
+## Impact
+
+- Users cannot reliably edit project tags using the correct itemType
+- Workaround exists but is confusing and semantically wrong
+- Silent failure makes debugging difficult
+
+## Suggested Fix
+
+Investigate why the project tag modification path doesn't apply changes. The task path appears to work for both tasks and projects, suggesting the project-specific code path may be missing tag handling logic.

--- a/docs/issues/features/2026-01-08-untagged-tasks-filter.md
+++ b/docs/issues/features/2026-01-08-untagged-tasks-filter.md
@@ -1,0 +1,58 @@
+# Feature Request: Filter for Untagged Tasks
+
+**Date:** 2026-01-08
+**Priority:** Medium
+
+## Summary
+
+Add the ability to filter for tasks that have no tags assigned. This would mirror the "Untagged" filter available in the OmniFocus native UI.
+
+## Use Case
+
+When performing tag cleanup or auditing task organization, users need to identify tasks that have no tags. Currently there's no way to query for untagged tasks via the MCP - you can filter BY tag, but not for the ABSENCE of tags.
+
+Example scenario: After bulk-removing obsolete tags (like PARA focus tags being replaced with action tags), users need to find tasks that were left without any tags so they can assign appropriate ones.
+
+## Proposed Implementation
+
+### Option A: New parameter on `filter_tasks`
+
+Add a boolean parameter `untagged`:
+
+```json
+{
+  "untagged": true,
+  "taskStatus": ["Available", "Next", "Blocked"]
+}
+```
+
+### Option B: Special value for `tagFilter`
+
+Allow a special value like `"none"` or `null` for tagFilter:
+
+```json
+{
+  "tagFilter": "none"
+}
+```
+
+### Option C: Dedicated tool
+
+Create `get_untagged_tasks` tool with standard filtering options:
+
+```json
+{
+  "taskStatus": ["Available", "Next", "Blocked"],
+  "projectFilter": "mixology",
+  "limit": 100
+}
+```
+
+## Recommendation
+
+Option A (parameter on `filter_tasks`) seems most consistent with the existing API design and keeps the tool count manageable.
+
+## Related
+
+- OmniFocus native UI has "Untagged" in the Tags perspective sidebar
+- Useful for tag hygiene and GTD maintenance workflows


### PR DESCRIPTION
## Summary
Add Sprint 9 plan to SPRINT_PROGRESS.md based on analysis of open issues in `docs/issues/`.

## Sprint 9 Overview

| Phase | Theme | Items |
|-------|-------|-------|
| 9A | Tag Operations (Critical) | B, A |
| 9B | Query Improvements | C, D |
| 9C | Filter Enhancements | E, F |
| 9D | Polish | G |

## Issues Addressed

| ID | Issue | Severity |
|----|-------|----------|
| A | Tag operations silent failure | HIGH |
| B | Project tag edit requires task itemType | HIGH |
| C | get_tasks_by_tag ignores dropped tags | MEDIUM |
| D | Task IDs missing from perspective output | MEDIUM |
| E | No way to filter untagged tasks | LOW |
| F | inInbox filter returns wrong results | MEDIUM |
| G | False "moved to folder" success message | LOW |

## Root Causes Identified
- **B**: `if (itemType === 'task')` guards in batchEditItems.js skip projects
- **C**: `flattenedTags.filter(tag => tag.active)` excludes dropped tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)