### PR TITLE
feat: Sprint 9B - Query improvements (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ get_tasks_by_tag {"tagId": ["tagId1", "tagId2"]}
 # Tasks by multiple tags (AND - all of these tags)
 get_tasks_by_tag {"tagName": ["home", "errands"], "tagMatchMode": "all"}
 
+# Include dropped/inactive tags in search
+get_tasks_by_tag {"tagId": "droppedTagId", "includeDropped": true}
+
 # List all tags (fast - ~400ms)
 list_tags {}
 

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,4 +1,4 @@
-# OmniFocus MCP Server - What's New (v1.24.0)
+# OmniFocus MCP Server - What's New (v1.25.0)
 
 > Summary of changes from Sprints 1-9 for AI assistants using this MCP server.
 
@@ -65,6 +65,11 @@
 ### list_tags Enhancement
 - Now shows tag status: active, (on hold), (dropped)
 - Use `edit_tag` to reactivate dropped tags
+
+### Sprint 9B: get_tasks_by_tag Enhancement
+- **New parameter**: `includeDropped: true` to search tasks by dropped/inactive tags
+- Default behavior unchanged (only searches active tags)
+- Use case: Find tasks blocked by tags that were later dropped
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/tools/definitions/getTasksByTag.ts
+++ b/src/tools/definitions/getTasksByTag.ts
@@ -9,6 +9,7 @@ export const schema = z.object({
   tagMatchMode: z.enum(["any", "all"]).optional().describe("How to match multiple tags: 'any' returns tasks with at least one tag (default), 'all' returns tasks with every specified tag"),
   hideCompleted: z.boolean().optional().describe("Set to false to show completed tasks with this tag (default: true)"),
   exactMatch: z.boolean().optional().describe("Set to true for exact tag name match, false for partial (default: false)"),
+  includeDropped: z.boolean().optional().describe("Set to true to include dropped/inactive tags in search (default: false). Useful for finding tasks with tags that were later dropped."),
   limit: z.number().optional().describe("Maximum number of tasks to return (default: 500). Use to prevent timeout with many tags")
 });
 
@@ -31,6 +32,7 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
       tagMatchMode: args.tagMatchMode || 'any',
       hideCompleted: args.hideCompleted !== false, // Default to true
       exactMatch: args.exactMatch || false,
+      includeDropped: args.includeDropped || false,
       limit: args.limit
     });
     

--- a/src/tools/primitives/getTasksByTag.ts
+++ b/src/tools/primitives/getTasksByTag.ts
@@ -6,11 +6,12 @@ export interface GetTasksByTagOptions {
   tagMatchMode?: 'any' | 'all';
   hideCompleted?: boolean;
   exactMatch?: boolean;
+  includeDropped?: boolean;
   limit?: number;
 }
 
 export async function getTasksByTag(options: GetTasksByTagOptions): Promise<string> {
-  const { tagName, tagId, tagMatchMode = 'any', hideCompleted = true, exactMatch = false, limit } = options;
+  const { tagName, tagId, tagMatchMode = 'any', hideCompleted = true, exactMatch = false, includeDropped = false, limit } = options;
 
   // Normalize to arrays
   const tagNames = tagName ? (Array.isArray(tagName) ? tagName : [tagName]).map(t => t.trim()).filter(t => t !== '') : [];
@@ -28,6 +29,7 @@ export async function getTasksByTag(options: GetTasksByTagOptions): Promise<stri
       tagMatchMode: tagMatchMode,
       hideCompleted: hideCompleted,
       exactMatch: exactMatch,
+      includeDropped: includeDropped,
       limit: limit ?? 500 // Default limit to prevent timeout with many tags
     });
     

--- a/src/utils/omnifocusScripts/tasksByTag.js
+++ b/src/utils/omnifocusScripts/tasksByTag.js
@@ -12,6 +12,7 @@
     const hideCompleted = args.hideCompleted !== false; // Default to true
     const exactMatch = args.exactMatch || false;
     const matchMode = args.tagMatchMode || 'any'; // 'any' (OR) or 'all' (AND)
+    const includeDropped = args.includeDropped === true; // Default to false
     const limit = (args.limit !== undefined && args.limit !== null) ? args.limit : 500; // Limit results to prevent timeout
 
     if (tagNames.length === 0 && tagIds.length === 0) {
@@ -38,8 +39,10 @@
       availableTags: []
     };
 
-    // Get all active tags for reference
-    const allTags = flattenedTags.filter(tag => tag.active);
+    // Get tags for reference (include dropped if requested)
+    const allTags = includeDropped
+      ? Array.from(flattenedTags)
+      : flattenedTags.filter(tag => tag.active);
     exportData.availableTags = allTags.map(tag => tag.name).sort();
 
     // Build tag ID map for ID lookups


### PR DESCRIPTION
## Summary
Add `includeDropped` parameter to `get_tasks_by_tag` to search for tasks using dropped/inactive tags.

## Changes
- **New parameter**: `includeDropped` (default: false)
  - When `false` (default): Only searches active tags (backward compatible)
  - When `true`: Includes dropped/inactive tags in search

## Files Changed
- `src/tools/definitions/getTasksByTag.ts` - Schema update
- `src/tools/primitives/getTasksByTag.ts` - Interface and parameter passing
- `src/utils/omnifocusScripts/tasksByTag.js` - OmniJS implementation
- `README.md` - Documentation
- `docs/WHATS_NEW.md` - Changelog
- `package.json` - Version 1.24.0 → 1.25.0

## Issues
- Fixes #45 (get_tasks_by_tag ignores dropped tags)
- Closes #46 (task IDs already present in perspective outputs)

## Use Case
Find tasks that were blocked by tags that were later dropped, e.g.:
```json
get_tasks_by_tag {"tagId": "droppedTagId", "includeDropped": true}
```

## Test plan
- [ ] Search by dropped tag name with `includeDropped: true`
- [ ] Search by dropped tag ID with `includeDropped: true`  
- [ ] Verify default behavior unchanged (only active tags searched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)