### PR TITLE
feat: Sprint 9C - Filter enhancements (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ filter_tasks {
   "taskStatus": ["Overdue", "DueSoon"]
 }
 
+# Find untagged tasks (useful after bulk tag cleanup)
+filter_tasks {
+  "untagged": true,
+  "taskStatus": ["Available", "Next"]
+}
+
 # Filter by project ID and tag ID (for programmatic use)
 filter_tasks {
   "projectId": "projectId123",

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,4 +1,4 @@
-# OmniFocus MCP Server - What's New (v1.25.0)
+# OmniFocus MCP Server - What's New (v1.26.0)
 
 > Summary of changes from Sprints 1-9 for AI assistants using this MCP server.
 
@@ -70,6 +70,11 @@
 - **New parameter**: `includeDropped: true` to search tasks by dropped/inactive tags
 - Default behavior unchanged (only searches active tags)
 - Use case: Find tasks blocked by tags that were later dropped
+
+### Sprint 9C: filter_tasks Enhancement
+- **New parameter**: `untagged: true` to filter for tasks with NO tags assigned
+- Use case: Find unorganized tasks after bulk tag removal
+- Example: `filter_tasks {"untagged": true, "taskStatus": ["Available"]}`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/tools/definitions/filterTasks.ts
+++ b/src/tools/definitions/filterTasks.ts
@@ -30,6 +30,7 @@ export const schema = z.object({
   tagFilter: z.union([z.string(), z.array(z.string())]).optional().describe("Filter by tag name(s). Can be single tag or array of tags"),
   tagId: z.union([z.string(), z.array(z.string())]).optional().describe("Filter by tag ID(s) (alternative to tagFilter). Can be single ID or array of IDs"),
   exactTagMatch: z.boolean().optional().describe("Set to true for exact tag name match, false for partial (default: false)"),
+  untagged: z.boolean().optional().describe("Filter for tasks with NO tags assigned. Useful after bulk tag removal to find unorganized tasks."),
 
   // Due date filtering
   dueBefore: z.string().optional().describe("Show tasks due before this date (ISO format: YYYY-MM-DD)"),

--- a/src/tools/primitives/filterTasks.ts
+++ b/src/tools/primitives/filterTasks.ts
@@ -21,6 +21,7 @@ export interface FilterTasksOptions {
   tagFilter?: string | string[];
   tagId?: string | string[];
   exactTagMatch?: boolean;
+  untagged?: boolean;
 
   // Due date filter
   dueBefore?: string;
@@ -198,7 +199,11 @@ function buildFilterSummary(options: FilterTasksOptions): string {
     const tags = Array.isArray(options.tagFilter) ? options.tagFilter.join(', ') : options.tagFilter;
     conditions.push(`Tags: ${tags}`);
   }
-  
+
+  if (options.untagged) {
+    conditions.push('Untagged: Yes');
+  }
+
   if (options.flagged !== undefined) {
     conditions.push(`Flagged: ${options.flagged ? 'Yes' : 'No'}`);
   }

--- a/src/utils/omnifocusScripts/filterTasks.js
+++ b/src/utils/omnifocusScripts/filterTasks.js
@@ -30,6 +30,7 @@
       tagFilter: args.tagFilter || null,
       tagId: args.tagId || null,
       exactTagMatch: args.exactTagMatch || false,
+      untagged: args.untagged === true,
       searchText: args.searchText || null,
       limit: args.limit || 100,
       sortBy: args.sortBy || "name",
@@ -202,6 +203,11 @@
           if (!hasMatchingTag) {
             return false;
           }
+        }
+
+        // Untagged filter - returns only tasks with no tags
+        if (filters.untagged && task.tags.length > 0) {
+          return false;
         }
 
         // Search text filter


### PR DESCRIPTION
## Summary

- **New `untagged` parameter for `filter_tasks`**: Filter for tasks with NO tags assigned
- **Closed #48**: After code review, `inInbox` filter logic was found to be correct (not a bug)

### Changes

| File | Change |
|------|--------|
| `src/utils/omnifocusScripts/filterTasks.js` | Added `untagged` filter logic |
| `src/tools/definitions/filterTasks.ts` | Added `untagged` to Zod schema |
| `src/tools/primitives/filterTasks.ts` | Added `untagged` to interface and filter summary |
| `docs/WHATS_NEW.md` | Added Sprint 9C section |
| `README.md` | Added untagged filter example |
| `package.json` | Version bump to 1.26.0 |

### Usage Example

```javascript
// Find untagged tasks (useful after bulk tag cleanup)
filter_tasks({
  untagged: true,
  taskStatus: ["Available", "Next"]
})
```

### Issue Resolution

- **#47**: ✅ Implemented - Added `untagged` filter parameter
- **#48**: ❌ Closed as not a bug - Code correctly uses `task.inInbox` property

## Test plan

- [ ] Test `filter_tasks` with `untagged: true` returns only tasks without tags
- [ ] Test `filter_tasks` with `untagged: false` or omitted returns normal behavior
- [ ] Test combining `untagged` with other filters (e.g., `taskStatus`, `projectFilter`)
- [ ] Verify cache invalidation works correctly with new parameter

🤖 Generated with [Claude Code](https://claude.ai/code)