### PR TITLE
docs: Mark seshat integrations as implemented

### DIFF
--- a/docs/seshat/README.md
+++ b/docs/seshat/README.md
@@ -6,8 +6,8 @@ Documentation for integrating of-mcp with seshat AI assistant skills.
 
 | File | Description | Status |
 |------|-------------|--------|
-| [skill-optimizations.md](skill-optimizations.md) | Batch operation optimizations for reset-habits, project-review, omnifocus-audit | Ready to implement |
-| [sprint9-integration.md](sprint9-integration.md) | How to use Sprint 9 features (untagged filter, includeDropped, project tags) | Ready to implement |
+| [skill-optimizations.md](skill-optimizations.md) | Batch operation optimizations for reset-habits, project-review, omnifocus-audit | ✅ Implemented |
+| [sprint9-integration.md](sprint9-integration.md) | How to use Sprint 9 features (untagged filter, includeDropped, project tags) | ✅ Implemented |
 | [sprint10-integration.md](sprint10-integration.md) | Future integration after Sprint 10 ships | Pending Sprint 10 |
 
 ## Quick Links

--- a/docs/seshat/skill-optimizations.md
+++ b/docs/seshat/skill-optimizations.md
@@ -1,7 +1,9 @@
 # Seshat Skill Optimization Plans
 
-> Implementation plans for optimizing OmniFocus MCP server usage in seshat skills.
-> These optimizations leverage batch operations for 9-12x performance improvements.
+> **Status: ✅ Implemented** (January 2026)
+
+Implementation plans for optimizing OmniFocus MCP server usage in seshat skills.
+These optimizations leverage batch operations for 9-12x performance improvements.
 
 ---
 

--- a/docs/seshat/sprint9-integration.md
+++ b/docs/seshat/sprint9-integration.md
@@ -1,6 +1,8 @@
 # Seshat Integration: Sprint 9 Features
 
-> How seshat skills can leverage new of-mcp v1.26.0 features from Sprint 9.
+> **Status: ✅ Implemented** (January 2026)
+
+How seshat skills can leverage new of-mcp v1.26.0 features from Sprint 9.
 
 ---
 


### PR DESCRIPTION
## Summary

Mark seshat integration documents as implemented after the seshat maintainer actioned them.

### Changes

- `skill-optimizations.md`: Added "Status: ✅ Implemented"
- `sprint9-integration.md`: Added "Status: ✅ Implemented"
- `README.md`: Updated status column

## Test plan

- [x] Documentation only

🤖 Generated with [Claude Code](https://claude.ai/code)