### PR TITLE
docs: Notify seshat maintainer about v1.27.1

### DIFF
--- a/docs/seshat/README.md
+++ b/docs/seshat/README.md
@@ -2,6 +2,31 @@
 
 Documentation for integrating of-mcp with seshat AI assistant skills.
 
+## ⚠️ v1.27.1 Update (January 2026)
+
+**Bug fix release** - IDs now included in add/create responses:
+
+```
+# Before v1.27.1
+✅ Task "Buy milk" created successfully in your inbox.
+
+# After v1.27.1
+✅ Task "Buy milk" (id: abc123) created successfully in your inbox.
+```
+
+**Impact on seshat skills:**
+- `batch_add_items` now returns IDs directly - no need to search for created items
+- Fixes the `/today` reset-habits issue where skill had to search for task IDs after creation
+- `add_omnifocus_task` and `add_project` also return IDs
+
+**search_tasks safeguard:**
+- Searches returning >500 matches (without project filter) now return guidance instead of timing out
+- Specific searches on large databases work fine
+
+See [WHATS_NEW.md](../WHATS_NEW.md) for full details.
+
+---
+
 ## Documents
 
 | File | Description | Status |
@@ -12,10 +37,12 @@ Documentation for integrating of-mcp with seshat AI assistant skills.
 
 ## Quick Links
 
-**Current features (v1.27.0):**
+**Current features (v1.27.1):**
+- IDs in add/create responses - Chain operations without searching
 - `get_system_health` tool - All health metrics in one call
 - `get_completion_stats` tool - Completion analytics by project/tag/folder
 - `countOnly: true` mode for filter_tasks - Fast counts without task data
 - `untagged: true` filter for finding uncategorized tasks
 - `includeDropped: true` for searching dropped tags
 - Tag operations on projects (`itemType: "project"`)
+- Result-count safeguard for search_tasks (>500 matches returns guidance)


### PR DESCRIPTION
## Summary

Update seshat documentation with v1.27.1 bug fix announcement.

## Changes

- Added v1.27.1 announcement section to seshat README
- Documents impact on seshat skills (fixes /today reset-habits issue)
- Updated quick links to v1.27.1 features

## For seshat maintainer

Key changes in v1.27.1:
- `batch_add_items`, `add_omnifocus_task`, `add_project` now return IDs in responses
- No more need to search for items after creating them
- `search_tasks` has result-count safeguard (>500 matches returns guidance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)