### PR TITLE
fix: Use reliable inInbox property for inbox count in systemHealth

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,15 @@
-# OmniFocus MCP Server - What's New (v1.27.1)
+# OmniFocus MCP Server - What's New (v1.27.2)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.27.2 Bug Fixes
+
+**Fixed `get_system_health` crashing with "inbox.tasks.length" error:**
+- The `inbox.tasks` property is not reliably available when running OmniJS via `evaluateJavascript()`
+- Changed to use `flattenedTasks.filter(task => task.inInbox)` which is the pattern used by all other scripts
+- This fixes the weekly review skill and any workflow using `get_system_health`
+
+---
 
 ## v1.27.1 Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/utils/omnifocusScripts/systemHealth.js
+++ b/src/utils/omnifocusScripts/systemHealth.js
@@ -7,8 +7,9 @@
       return taskStatusMap[status] || "Unknown";
     }
 
-    // Count inbox tasks
-    const inboxCount = inbox.tasks.length;
+    // Count inbox tasks using the reliable inInbox property
+    // Note: inbox.tasks doesn't work reliably via evaluateJavascript()
+    const inboxCount = flattenedTasks.filter(task => task.inInbox).length;
 
     // Count projects by status
     const projects = {


### PR DESCRIPTION
## Summary
- Fixed `get_system_health` crashing with `TypeError: undefined is not an object (evaluating 'inbox.tasks.length')`
- The `inbox.tasks` property is not reliably available when running OmniJS via `evaluateJavascript()`
- Changed to use `flattenedTasks.filter(task => task.inInbox)` which is the pattern used by all other scripts

## Test plan
- [ ] Run seshat weekly review skill and verify `get_system_health` no longer crashes
- [ ] Verify inbox count is accurate in the system health output

🤖 Generated with [Claude Code](https://claude.com/claude-code)