### PR TITLE
fix: Exclude project root tasks from untagged/flagged counts

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,15 @@
-# OmniFocus MCP Server - What's New (v1.27.3)
+# OmniFocus MCP Server - What's New (v1.27.4)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.27.4 Bug Fixes
+
+**Fixed `get_system_health` untagged and flagged counts:**
+- Untagged/flagged counts now exclude project root tasks (project titles)
+- Now uses same active status filter as inbox count (Available, DueSoon, Next, Overdue)
+- Consistent with OF Statistics plug-in behavior
+
+---
 
 ## v1.27.3 Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.27.3",
+  "version": "1.27.4",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/utils/omnifocusScripts/systemHealth.js
+++ b/src/utils/omnifocusScripts/systemHealth.js
@@ -94,13 +94,17 @@
           break;
       }
 
-      // Count flagged (only among active tasks)
-      if (task.flagged && status !== "Completed" && status !== "Dropped") {
+      // Count flagged (only among active tasks, exclude project root tasks)
+      if (task.flagged &&
+          !task.project &&
+          activeStatuses.includes(task.taskStatus)) {
         flaggedCount++;
       }
 
-      // Count untagged (only among active tasks)
-      if (task.tags.length === 0 && status !== "Completed" && status !== "Dropped") {
+      // Count untagged (only among active tasks, exclude project root tasks)
+      if (task.tags.length === 0 &&
+          !task.project &&
+          activeStatuses.includes(task.taskStatus)) {
         untaggedCount++;
       }
     });


### PR DESCRIPTION
## Summary
- Untagged and flagged counts now exclude project root tasks (project titles)
- Uses same `activeStatuses` filter as inbox count (Available, DueSoon, Next, Overdue)
- Matches OF Statistics plug-in behavior

## Changes
- `systemHealth.js`: Added `!task.project` check and `activeStatuses.includes()` filter
- Version bump to 1.27.4

## Test plan
- [ ] Run `get_system_health()` and verify untagged count is lower (no project titles)
- [ ] Compare with OF Statistics plug-in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)