### PR TITLE
fix: Improve error handling patterns (Issue #64)

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,24 @@
-# OmniFocus MCP Server - What's New (v1.28.3)
+# OmniFocus MCP Server - What's New (v1.29.0)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.29.0 Error Handling Improvements
+
+**Improved error visibility and debugging:**
+- Unexpected OmniFocus result formats now log diagnostic details before throwing (Issue #64)
+- 7 primitive functions updated to log `resultType` and `result` for debugging
+- Silent returns replaced with explicit errors for fail-fast behavior
+
+**Safe date formatting utility:**
+- New `formatDateSafe()` utility handles invalid dates gracefully
+- Returns `null` instead of "Invalid Date" for malformed date strings
+- Applied to `get_task_by_id`, `add_omnifocus_task`, `add_project`, `list_projects`
+
+**Code consistency:**
+- Standardized unused parameter naming (`_extra`) across 23 handler functions
+- Follows TypeScript convention for intentionally unused parameters
+
+---
 
 ## v1.28.3 Enhancement
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.28.3",
+  "version": "1.29.0",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/tools/definitions/addFolder.ts
+++ b/src/tools/definitions/addFolder.ts
@@ -9,7 +9,7 @@ export const schema = z.object({
   parentFolderId: z.string().optional().describe("Parent folder ID (alternative to parentFolderName)")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     // Call the addFolder function
     const result = await addFolder(args as AddFolderParams);

--- a/src/tools/definitions/addOmniFocusTask.ts
+++ b/src/tools/definitions/addOmniFocusTask.ts
@@ -4,6 +4,7 @@ import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.j
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
 import { repetitionRuleSchema } from '../../schemas/repetitionRule.js';
 import { logger } from '../../utils/logger.js';
+import { formatDateSafe } from '../../utils/dateUtils.js';
 
 const log = logger.child('addOmniFocusTask:handler');
 
@@ -44,12 +45,14 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
         ? ` with tags: ${args.tags.join(', ')}`
         : "";
         
-      let dueDateText = args.dueDate
-        ? ` due on ${new Date(args.dueDate).toLocaleDateString()}`
+      const formattedDue = formatDateSafe(args.dueDate);
+      let dueDateText = formattedDue
+        ? ` due on ${formattedDue}`
         : "";
 
-      let plannedDateText = args.plannedDate
-        ? ` planned for ${new Date(args.plannedDate).toLocaleDateString()}`
+      const formattedPlanned = formatDateSafe(args.plannedDate);
+      let plannedDateText = formattedPlanned
+        ? ` planned for ${formattedPlanned}`
         : "";
 
       let repeatText = "";

--- a/src/tools/definitions/addProject.ts
+++ b/src/tools/definitions/addProject.ts
@@ -3,6 +3,7 @@ import { addProject, AddProjectParams } from '../primitives/addProject.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
 import { logger } from '../../utils/logger.js';
+import { formatDateSafe } from '../../utils/dateUtils.js';
 
 const log = logger.child('addProject:handler');
 
@@ -34,8 +35,9 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
         ? ` with tags: ${args.tags.join(', ')}`
         : "";
         
-      let dueDateText = args.dueDate
-        ? ` due on ${new Date(args.dueDate).toLocaleDateString()}`
+      const formattedDue = formatDateSafe(args.dueDate);
+      let dueDateText = formattedDue
+        ? ` due on ${formattedDue}`
         : "";
         
       let sequentialText = args.sequential

--- a/src/tools/definitions/batchAddItems.ts
+++ b/src/tools/definitions/batchAddItems.ts
@@ -35,7 +35,7 @@ export const schema = z.object({
   })).describe("Array of items (tasks or projects) to add")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     // Call the batchAddItems function (now uses true batching - single OmniJS script)
     const result = await batchAddItems(args.items as BatchAddItemsParams[]);

--- a/src/tools/definitions/batchEditItems.ts
+++ b/src/tools/definitions/batchEditItems.ts
@@ -48,7 +48,7 @@ export const schema = z.object({
   edits: z.array(editItemSchema).describe("Array of edit operations to perform")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     if (!args.edits || args.edits.length === 0) {
       return {

--- a/src/tools/definitions/batchFilterTasks.ts
+++ b/src/tools/definitions/batchFilterTasks.ts
@@ -36,7 +36,7 @@ export const schema = z.object({
   sortOrder: z.enum(["asc", "desc"]).optional().describe("Sort order (default: asc)")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     // Validate that at least one project filter is provided
     if ((!args.projectIds || args.projectIds.length === 0) &&

--- a/src/tools/definitions/batchMarkReviewed.ts
+++ b/src/tools/definitions/batchMarkReviewed.ts
@@ -8,7 +8,7 @@ export const schema = z.object({
   projectNames: z.array(z.string()).optional().describe("Array of project names to mark as reviewed (alternative to projectIds)")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     // Validate at least one identifier array is provided
     const hasIds = args.projectIds && args.projectIds.length > 0;

--- a/src/tools/definitions/batchRemoveItems.ts
+++ b/src/tools/definitions/batchRemoveItems.ts
@@ -11,7 +11,7 @@ export const schema = z.object({
   })).describe("Array of items (tasks or projects) to remove")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     // Validate that each item has at least an ID or name
     for (const item of args.items) {

--- a/src/tools/definitions/duplicateProject.ts
+++ b/src/tools/definitions/duplicateProject.ts
@@ -37,7 +37,7 @@ const validationSchema = schema.refine(
   { message: "Either sourceProjectId or sourceProjectName is required" }
 );
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     // Validate that either sourceProjectId or sourceProjectName is provided
     const validated = validationSchema.parse(args);

--- a/src/tools/definitions/editItem.ts
+++ b/src/tools/definitions/editItem.ts
@@ -47,7 +47,7 @@ export const schema = z.object({
   newNextReviewDate: z.string().optional().describe("Set next review date directly (ISO format YYYY-MM-DD). Only applies to projects.")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     // Validate that either id or name is provided
     if (!args.id && !args.name) {

--- a/src/tools/definitions/editTag.ts
+++ b/src/tools/definitions/editTag.ts
@@ -32,7 +32,7 @@ const validationSchema = schema.refine(
   { message: "At least one change parameter is required (newName, newStatus, newParentTagId, newParentTagName, or allowsNextAction)" }
 );
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     // Validate input requirements
     const validated = validationSchema.parse(args);

--- a/src/tools/definitions/filterTasks.ts
+++ b/src/tools/definitions/filterTasks.ts
@@ -76,7 +76,7 @@ export const schema = z.object({
   countOnly: z.boolean().optional().describe("Return only the count of matching tasks, not the task data. Much faster for health checks and dashboards.")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     const result = await filterTasks(args);
     

--- a/src/tools/definitions/getCustomPerspectiveTasks.ts
+++ b/src/tools/definitions/getCustomPerspectiveTasks.ts
@@ -11,7 +11,7 @@ export const schema = z.object({
   showHierarchy: z.boolean().optional().describe("Display tasks in hierarchical tree structure showing parent-child relationships (default: false)")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     // Validate that at least one identifier is provided
     if (!args.perspectiveName && !args.perspectiveId) {

--- a/src/tools/definitions/getFlaggedTasks.ts
+++ b/src/tools/definitions/getFlaggedTasks.ts
@@ -9,7 +9,7 @@ export const schema = z.object({
   projectId: z.string().optional().describe("Filter flagged tasks by project ID (alternative to projectFilter)")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     const result = await getFlaggedTasks({
       hideCompleted: args.hideCompleted !== false, // Default to true

--- a/src/tools/definitions/getFolderById.ts
+++ b/src/tools/definitions/getFolderById.ts
@@ -8,7 +8,7 @@ export const schema = z.object({
   folderName: z.string().optional().describe("The name of the folder to retrieve (alternative to folderId)")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     // Validate that either folderId or folderName is provided
     if (!args.folderId && !args.folderName) {

--- a/src/tools/definitions/getForecastTasks.ts
+++ b/src/tools/definitions/getForecastTasks.ts
@@ -9,7 +9,7 @@ export const schema = z.object({
   includeDeferredOnly: z.boolean().optional().describe("Set to true to show only deferred tasks becoming available (default: false)")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     const result = await getForecastTasks({
       days: args.days || 7,

--- a/src/tools/definitions/getInboxTasks.ts
+++ b/src/tools/definitions/getInboxTasks.ts
@@ -7,7 +7,7 @@ export const schema = z.object({
   hideCompleted: z.boolean().optional().describe("Set to false to show completed tasks in inbox (default: true)")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     const result = await getInboxTasks({
       hideCompleted: args.hideCompleted !== false // Default to true

--- a/src/tools/definitions/getProjectById.ts
+++ b/src/tools/definitions/getProjectById.ts
@@ -8,7 +8,7 @@ export const schema = z.object({
   projectName: z.string().optional().describe("The name of the project to retrieve (alternative to projectId)")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     // Validate that either projectId or projectName is provided
     if (!args.projectId && !args.projectName) {

--- a/src/tools/definitions/getProjectsForReview.ts
+++ b/src/tools/definitions/getProjectsForReview.ts
@@ -8,7 +8,7 @@ export const schema = z.object({
   limit: z.number().optional().describe("Maximum number of projects to return (default: 50)")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     // Call the getProjectsForReview function
     const result = await getProjectsForReview(args as GetProjectsForReviewParams);

--- a/src/tools/definitions/getTaskById.ts
+++ b/src/tools/definitions/getTaskById.ts
@@ -2,13 +2,14 @@ import { z } from 'zod';
 import { getTaskById, GetTaskByIdParams } from '../primitives/getTaskById.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
+import { formatDateSafe } from '../../utils/dateUtils.js';
 
 export const schema = z.object({
   taskId: z.string().optional().describe("The ID of the task to retrieve"),
   taskName: z.string().optional().describe("The name of the task to retrieve (alternative to taskId)")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     // Validate that either taskId or taskName is provided
     if (!args.taskId && !args.taskName) {
@@ -44,20 +45,24 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
         infoText += `• **Project**: ${task.projectName} (${task.projectId})\n`;
       }
 
-      if (task.dueDate) {
-        infoText += `• **Due Date**: ${new Date(task.dueDate).toLocaleDateString()}\n`;
+      const dueDate = formatDateSafe(task.dueDate);
+      if (dueDate) {
+        infoText += `• **Due Date**: ${dueDate}\n`;
       }
 
-      if (task.deferDate) {
-        infoText += `• **Defer Date**: ${new Date(task.deferDate).toLocaleDateString()}\n`;
+      const deferDate = formatDateSafe(task.deferDate);
+      if (deferDate) {
+        infoText += `• **Defer Date**: ${deferDate}\n`;
       }
 
-      if (task.plannedDate) {
-        infoText += `• **Planned Date**: ${new Date(task.plannedDate).toLocaleDateString()}\n`;
+      const plannedDate = formatDateSafe(task.plannedDate);
+      if (plannedDate) {
+        infoText += `• **Planned Date**: ${plannedDate}\n`;
       }
 
-      if (task.createdDate) {
-        infoText += `• **Created**: ${new Date(task.createdDate).toLocaleDateString()}\n`;
+      const createdDate = formatDateSafe(task.createdDate);
+      if (createdDate) {
+        infoText += `• **Created**: ${createdDate}\n`;
       }
 
       infoText += `• **Has Children**: ${task.hasChildren ? `Yes (${task.childrenCount} subtasks)` : 'No'}\n`;

--- a/src/tools/definitions/getTasksByTag.ts
+++ b/src/tools/definitions/getTasksByTag.ts
@@ -13,7 +13,7 @@ export const schema = z.object({
   limit: z.number().optional().describe("Maximum number of tasks to return (default: 500). Use to prevent timeout with many tags")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     // Validate that at least one of tagName or tagId is provided
     if (!args.tagName && !args.tagId) {

--- a/src/tools/definitions/listCustomPerspectives.ts
+++ b/src/tools/definitions/listCustomPerspectives.ts
@@ -7,7 +7,7 @@ export const schema = z.object({
   format: z.enum(['simple', 'detailed']).optional().describe("Output format: simple (names only) or detailed (with identifiers) - default: simple")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     const result = await listCustomPerspectives({
       format: args.format || 'simple'

--- a/src/tools/definitions/listProjects.ts
+++ b/src/tools/definitions/listProjects.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { listProjects } from '../primitives/listProjects.js';
+import { formatDateSafe } from '../../utils/dateUtils.js';
 
 export const schema = z.object({
   folderName: z.string().optional().describe("Filter by folder name"),
@@ -54,9 +55,7 @@ export async function handler(
 
       // Table rows
       for (const project of result.projects) {
-        const reviewDate = project.nextReviewDate
-          ? new Date(project.nextReviewDate).toLocaleDateString()
-          : '-';
+        const reviewDate = formatDateSafe(project.nextReviewDate) || '-';
         const folderDisplay = project.folderName || '(root)';
 
         output += `| ${project.name} | ${project.status} | ${project.taskCount} | ${reviewDate} | ${folderDisplay} |\n`;

--- a/src/tools/definitions/listTags.ts
+++ b/src/tools/definitions/listTags.ts
@@ -8,7 +8,7 @@ export const schema = z.object({
   showTaskCounts: z.boolean().optional().describe("Show task counts per tag - slower but more informative (default: false)")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     const result = await listTags({
       includeDropped: args.includeDropped || false,

--- a/src/tools/definitions/removeItem.ts
+++ b/src/tools/definitions/removeItem.ts
@@ -9,7 +9,7 @@ export const schema = z.object({
   itemType: z.enum(['task', 'project']).describe("Type of item to remove ('task' or 'project')")
 });
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     // Validate that either id or name is provided
     if (!args.id && !args.name) {

--- a/src/tools/definitions/systemHealth.ts
+++ b/src/tools/definitions/systemHealth.ts
@@ -5,7 +5,7 @@ import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/typ
 
 export const schema = z.object({});
 
-export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
+export async function handler(args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
     const result = await getSystemHealth();
 

--- a/src/tools/primitives/batchFilterTasks.ts
+++ b/src/tools/primitives/batchFilterTasks.ts
@@ -1,4 +1,7 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('batchFilterTasks');
 
 export interface BatchFilterTasksOptions {
   // Project filters
@@ -56,10 +59,11 @@ export async function batchFilterTasks(options: BatchFilterTasksOptions = {}): P
       return formatBatchResults(data, options);
     }
 
-    return "Unexpected result format from OmniFocus";
+    log.error('Unexpected result format', { resultType: typeof result, result });
+    throw new Error('Unexpected result format from OmniFocus');
 
   } catch (error) {
-    console.error("Error in batchFilterTasks:", error);
+    log.error('Error in batchFilterTasks', { error: error instanceof Error ? error.message : String(error) });
     throw new Error(`Failed to batch filter tasks: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
 }

--- a/src/tools/primitives/filterTasks.ts
+++ b/src/tools/primitives/filterTasks.ts
@@ -183,7 +183,8 @@ export async function filterTasks(options: FilterTasksOptions = {}): Promise<str
       return output;
     }
 
-    return "Unexpected result format from OmniFocus";
+    log.error('Unexpected result format', { resultType: typeof result, result });
+    throw new Error('Unexpected result format from OmniFocus');
 
   } catch (error) {
     log.error('Error in filterTasks', { error: error instanceof Error ? error.message : String(error) });

--- a/src/tools/primitives/getFlaggedTasks.ts
+++ b/src/tools/primitives/getFlaggedTasks.ts
@@ -1,4 +1,7 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('getFlaggedTasks');
 
 export interface GetFlaggedTasksOptions {
   hideCompleted?: boolean;
@@ -91,10 +94,11 @@ export async function getFlaggedTasks(options: GetFlaggedTasksOptions = {}): Pro
       return output;
     }
     
-    return "Unexpected result format from OmniFocus";
-    
+    log.error('Unexpected result format', { resultType: typeof result, result });
+    throw new Error('Unexpected result format from OmniFocus');
+
   } catch (error) {
-    console.error("Error in getFlaggedTasks:", error);
+    log.error('Error in getFlaggedTasks', { error: error instanceof Error ? error.message : String(error) });
     throw new Error(`Failed to get flagged tasks: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
 }

--- a/src/tools/primitives/getForecastTasks.ts
+++ b/src/tools/primitives/getForecastTasks.ts
@@ -1,4 +1,7 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('getForecastTasks');
 
 export interface GetForecastTasksOptions {
   days?: number;
@@ -93,10 +96,11 @@ export async function getForecastTasks(options: GetForecastTasksOptions = {}): P
       return output;
     }
     
-    return "Unexpected result format from OmniFocus";
-    
+    log.error('Unexpected result format', { resultType: typeof result, result });
+    throw new Error('Unexpected result format from OmniFocus');
+
   } catch (error) {
-    console.error("Error in getForecastTasks:", error);
+    log.error('Error in getForecastTasks', { error: error instanceof Error ? error.message : String(error) });
     throw new Error(`Failed to get forecast tasks: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
 }

--- a/src/tools/primitives/getInboxTasks.ts
+++ b/src/tools/primitives/getInboxTasks.ts
@@ -1,4 +1,7 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('getInboxTasks');
 
 export interface GetInboxTasksOptions {
   hideCompleted?: boolean;
@@ -54,10 +57,11 @@ export async function getInboxTasks(options: GetInboxTasksOptions = {}): Promise
       return output;
     }
     
-    return "Unexpected result format from OmniFocus";
-    
+    log.error('Unexpected result format', { resultType: typeof result, result });
+    throw new Error('Unexpected result format from OmniFocus');
+
   } catch (error) {
-    console.error("Error in getInboxTasks:", error);
+    log.error('Error in getInboxTasks', { error: error instanceof Error ? error.message : String(error) });
     throw new Error(`Failed to get inbox tasks: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
 }

--- a/src/tools/primitives/getTasksByTag.ts
+++ b/src/tools/primitives/getTasksByTag.ts
@@ -1,4 +1,7 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('getTasksByTag');
 
 export interface GetTasksByTagOptions {
   tagName?: string | string[];
@@ -146,10 +149,11 @@ export async function getTasksByTag(options: GetTasksByTagOptions): Promise<stri
       return output;
     }
     
-    return "Unexpected result format from OmniFocus";
-    
+    log.error('Unexpected result format', { resultType: typeof result, result });
+    throw new Error('Unexpected result format from OmniFocus');
+
   } catch (error) {
-    console.error("Error in getTasksByTag:", error);
+    log.error('Error in getTasksByTag', { error: error instanceof Error ? error.message : String(error) });
     throw new Error(`Failed to get tasks by tag: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
 }

--- a/src/tools/primitives/searchTasks.ts
+++ b/src/tools/primitives/searchTasks.ts
@@ -48,7 +48,8 @@ export async function searchTasks(options: SearchTasksOptions): Promise<string> 
     } else if (result && typeof result === 'object') {
       parsed = result as SearchResult;
     } else {
-      return "Unexpected result format from OmniFocus";
+      log.error('Unexpected result format', { resultType: typeof result, result });
+      throw new Error('Unexpected result format from OmniFocus');
     }
 
     // Cache the result

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,21 @@
+/**
+ * Date formatting utilities with safe handling of invalid dates
+ */
+
+/**
+ * Safely formats a date string to locale date string.
+ * Returns null for invalid, null, or undefined date inputs.
+ *
+ * @param dateString - ISO date string, or null/undefined
+ * @returns Formatted date string or null if invalid
+ */
+export function formatDateSafe(dateString: string | null | undefined): string | null {
+  if (!dateString) return null;
+
+  const date = new Date(dateString);
+  if (isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toLocaleDateString();
+}


### PR DESCRIPTION
## Summary
- Add logging with diagnostic context before throwing for unexpected OmniFocus result formats
- Create `formatDateSafe()` utility for graceful handling of invalid dates (returns `null` instead of "Invalid Date")
- Standardize unused parameter naming (`extra` -> `_extra`) across 23 handler functions

## Changes

| Category | Files | Description |
|----------|-------|-------------|
| Silent returns → logged errors | 7 primitives | `searchTasks`, `getInboxTasks`, `batchFilterTasks`, `getForecastTasks`, `getTasksByTag`, `getFlaggedTasks`, `filterTasks` |
| Safe date formatting | 4 definitions | `getTaskById`, `addOmniFocusTask`, `addProject`, `listProjects` |
| Parameter naming | 23 definitions | All handler functions with unused `extra` parameter |
| New utility | 1 file | `src/utils/dateUtils.ts` |

## Test plan
- [ ] Run `npm run build` - verify no TypeScript errors
- [ ] Test a tool that uses date formatting (e.g., `get_task_by_id`) with valid dates
- [ ] Verify error messages still propagate correctly for failed operations

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)