### PR TITLE
fix: Apply formatDateSafe and standardize logging across primitives

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,45 @@
-# OmniFocus MCP Server - What's New (v1.29.0)
+# OmniFocus MCP Server - What's New (v1.29.2)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.29.2 Logging Standardization
+
+**Structured logging now consistent across all primitive files (Issue #82):**
+- All 10 remaining primitive files migrated from `console.error` to structured `logger` utility
+- Debug output uses `log.debug()`, error handling uses `log.error()`
+- Each primitive has a descriptive logger child name (e.g., `of-mcp:getFolderById`)
+- Logs are written to stderr with timestamps and structured context objects
+
+**Files updated:**
+- `batchFilterTasks.ts`, `getCustomPerspectiveTasks.ts`, `getFolderById.ts`
+- `getPerspectiveTasksV2.ts`, `getProjectById.ts`, `getProjectsForReview.ts`
+- `getTodayCompletedTasks.ts`, `listCustomPerspectives.ts`, `listProjects.ts`, `listTags.ts`
+
+**Benefits:**
+- Consistent log format across all modules for easier debugging
+- Log level filtering via `LOG_LEVEL` environment variable (debug, info, warn, error, silent)
+- Structured context objects instead of string concatenation
+
+---
+
+## v1.29.1 Safe Date Formatting Extended
+
+**`formatDateSafe()` now applied across all task-returning primitives (Issue #81):**
+- Extended safe date handling from 4 definition files to all 8 primitive files
+- 21 instances of date formatting now use `formatDateSafe()` instead of raw `new Date().toLocaleDateString()`
+- Prevents "Invalid Date" strings from appearing in output when OmniFocus returns malformed dates
+
+**Affected files:**
+- `filterTasks.ts` (5 instances: createdDate, dueDate, deferDate, plannedDate, completedDate)
+- `getCustomPerspectiveTasks.ts` (4 instances: dueDate x2, createdDate x2)
+- `batchFilterTasks.ts` (3 instances: createdDate, dueDate, deferDate)
+- `getFlaggedTasks.ts` (3 instances: dueDate, deferDate, createdDate)
+- `getTasksByTag.ts` (3 instances: dueDate, deferDate, createdDate)
+- `searchTasks.ts` (2 instances: dueDate, createdDate)
+- `getInboxTasks.ts` (2 instances: dueDate, createdDate)
+- `getForecastTasks.ts` (1 instance: createdDate)
+
+---
 
 ## v1.29.0 Error Handling Improvements
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.29.0",
+  "version": "1.29.2",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/tools/primitives/batchFilterTasks.ts
+++ b/src/tools/primitives/batchFilterTasks.ts
@@ -1,5 +1,6 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
 import { logger } from '../../utils/logger.js';
+import { formatDateSafe } from '../../utils/dateUtils.js';
 
 const log = logger.child('batchFilterTasks');
 
@@ -33,9 +34,10 @@ export async function batchFilterTasks(options: BatchFilterTasksOptions = {}): P
       sortOrder = "asc"
     } = options;
 
-    console.error("Executing batch filter for projects...");
-    console.error(`Project IDs: ${options.projectIds?.join(', ') || 'none'}`);
-    console.error(`Project Names: ${options.projectNames?.join(', ') || 'none'}`);
+    log.debug('Executing batch filter for projects', {
+      projectIds: options.projectIds || [],
+      projectNames: options.projectNames || []
+    });
 
     const result = await executeOmniFocusScript('@batchFilterTasks.js', {
       ...options,
@@ -144,21 +146,23 @@ function formatTask(task: any): string {
   }
 
   // Created date
-  if (task.createdDate) {
-    output += ` (created: ${new Date(task.createdDate).toLocaleDateString()})`;
+  const createdDateStr = formatDateSafe(task.createdDate);
+  if (createdDateStr) {
+    output += ` (created: ${createdDateStr})`;
   }
 
   output += '\n';
 
   // Date info
-  if (task.dueDate) {
-    const dueDateStr = new Date(task.dueDate).toLocaleDateString();
+  const dueDateStr = formatDateSafe(task.dueDate);
+  if (dueDateStr) {
     const isOverdue = new Date(task.dueDate) < new Date();
     output += `  ${isOverdue ? '⚠️' : '📅'} Due: ${dueDateStr}\n`;
   }
 
-  if (task.deferDate) {
-    output += `  🚀 Defer: ${new Date(task.deferDate).toLocaleDateString()}\n`;
+  const deferDateStr = formatDateSafe(task.deferDate);
+  if (deferDateStr) {
+    output += `  🚀 Defer: ${deferDateStr}\n`;
   }
 
   // Tags

--- a/src/tools/primitives/filterTasks.ts
+++ b/src/tools/primitives/filterTasks.ts
@@ -1,6 +1,7 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
 import { queryCache } from '../../utils/cache.js';
 import { logger } from '../../utils/logger.js';
+import { formatDateSafe } from '../../utils/dateUtils.js';
 
 const log = logger.child('filterTasks');
 
@@ -289,30 +290,31 @@ function formatTask(task: any): string {
   }
 
   // Created date
-  if (task.createdDate) {
-    output += ` (created: ${new Date(task.createdDate).toLocaleDateString()})`;
+  const createdDateStr = formatDateSafe(task.createdDate);
+  if (createdDateStr) {
+    output += ` (created: ${createdDateStr})`;
   }
 
   // Date info
   const dateInfo: string[] = [];
-  if (task.dueDate) {
-    const dueDateStr = new Date(task.dueDate).toLocaleDateString();
+  const dueDateStr = formatDateSafe(task.dueDate);
+  if (dueDateStr) {
     const isOverdue = new Date(task.dueDate) < new Date();
     dateInfo.push(isOverdue ? `⚠️ DUE: ${dueDateStr}` : `📅 DUE: ${dueDateStr}`);
   }
 
-  if (task.deferDate) {
-    const deferDateStr = new Date(task.deferDate).toLocaleDateString();
+  const deferDateStr = formatDateSafe(task.deferDate);
+  if (deferDateStr) {
     dateInfo.push(`🚀 DEFER: ${deferDateStr}`);
   }
 
-  if (task.plannedDate) {
-    const plannedDateStr = new Date(task.plannedDate).toLocaleDateString();
+  const plannedDateStr = formatDateSafe(task.plannedDate);
+  if (plannedDateStr) {
     dateInfo.push(`📋 PLANNED: ${plannedDateStr}`);
   }
 
-  if (task.completedDate) {
-    const completedDateStr = new Date(task.completedDate).toLocaleDateString();
+  const completedDateStr = formatDateSafe(task.completedDate);
+  if (completedDateStr) {
     dateInfo.push(`✅ DONE: ${completedDateStr}`);
   }
 

--- a/src/tools/primitives/getCustomPerspectiveTasks.ts
+++ b/src/tools/primitives/getCustomPerspectiveTasks.ts
@@ -1,4 +1,8 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
+import { formatDateSafe } from '../../utils/dateUtils.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('getCustomPerspectiveTasks');
 
 export interface GetCustomPerspectiveTasksOptions {
   perspectiveName?: string;
@@ -67,7 +71,7 @@ export async function getCustomPerspectiveTasks(options: GetCustomPerspectiveTas
     }
 
   } catch (error) {
-    console.error('Error in getCustomPerspectiveTasks:', error);
+    log.error('Error in getCustomPerspectiveTasks', { error: error instanceof Error ? error.message : String(error) });
     return `❌ **Error**: ${error instanceof Error ? error.message : String(error)}`;
   }
 }
@@ -158,13 +162,14 @@ function formatTaskDetails(task: any): string[] {
     details.push(`Tags: ${task.tags.join(', ')}`);
   }
 
-  if (task.dueDate) {
-    const dueDate = new Date(task.dueDate).toLocaleDateString();
+  const dueDate = formatDateSafe(task.dueDate);
+  if (dueDate) {
     details.push(`Due: ${dueDate}`);
   }
 
-  if (task.createdDate) {
-    details.push(`Created: ${new Date(task.createdDate).toLocaleDateString()}`);
+  const createdDate = formatDateSafe(task.createdDate);
+  if (createdDate) {
+    details.push(`Created: ${createdDate}`);
   }
 
   if (task.estimatedMinutes) {
@@ -205,13 +210,14 @@ function formatFlatTasks(perspectiveName: string, tasks: any[], limit: number, t
       taskText += `\n   Tags: ${task.tags.join(', ')}`;
     }
 
-    if (task.dueDate) {
-      const dueDate = new Date(task.dueDate).toLocaleDateString();
+    const dueDate = formatDateSafe(task.dueDate);
+    if (dueDate) {
       taskText += `\n   Due: ${dueDate}`;
     }
 
-    if (task.createdDate) {
-      taskText += `\n   Created: ${new Date(task.createdDate).toLocaleDateString()}`;
+    const createdDate = formatDateSafe(task.createdDate);
+    if (createdDate) {
+      taskText += `\n   Created: ${createdDate}`;
     }
 
     if (task.flagged) {

--- a/src/tools/primitives/getFlaggedTasks.ts
+++ b/src/tools/primitives/getFlaggedTasks.ts
@@ -1,5 +1,6 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
 import { logger } from '../../utils/logger.js';
+import { formatDateSafe } from '../../utils/dateUtils.js';
 
 const log = logger.child('getFlaggedTasks');
 
@@ -66,11 +67,11 @@ export async function getFlaggedTasks(options: GetFlaggedTasksOptions = {}): Pro
             }
             
             tasks.forEach((task: any, index: number) => {
-              const dueDateStr = task.dueDate ? ` [DUE: ${new Date(task.dueDate).toLocaleDateString()}]` : '';
-              const deferDateStr = task.deferDate ? ` [DEFER: ${new Date(task.deferDate).toLocaleDateString()}]` : '';
+              const dueDateStr = task.dueDate ? ` [DUE: ${formatDateSafe(task.dueDate)}]` : '';
+              const deferDateStr = task.deferDate ? ` [DEFER: ${formatDateSafe(task.deferDate)}]` : '';
               const statusStr = task.taskStatus !== 'Available' ? ` (${task.taskStatus})` : '';
               const estimateStr = task.estimatedMinutes ? ` ⏱${task.estimatedMinutes}m` : '';
-              const createdStr = task.createdDate ? ` (created: ${new Date(task.createdDate).toLocaleDateString()})` : '';
+              const createdStr = task.createdDate ? ` (created: ${formatDateSafe(task.createdDate)})` : '';
 
               output += `• 🚩 ${task.name}${dueDateStr}${deferDateStr}${statusStr}${estimateStr} [ID: ${task.id}]${createdStr}\n`;
               

--- a/src/tools/primitives/getFolderById.ts
+++ b/src/tools/primitives/getFolderById.ts
@@ -1,4 +1,7 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('getFolderById');
 
 // Interface for folder lookup parameters
 export interface GetFolderByIdParams {
@@ -31,8 +34,10 @@ export async function getFolderById(params: GetFolderByIdParams): Promise<{succe
       };
     }
 
-    console.error("Executing OmniJS script for getFolderById...");
-    console.error(`Parameters: folderId=${params.folderId}, folderName=${params.folderName}`);
+    log.debug('Executing OmniJS script for getFolderById', {
+      folderId: params.folderId,
+      folderName: params.folderName
+    });
 
     // Execute the OmniJS script
     const result = await executeOmniFocusScript('@getFolderByName.js', {
@@ -46,7 +51,7 @@ export async function getFolderById(params: GetFolderByIdParams): Promise<{succe
       try {
         parsed = JSON.parse(result);
       } catch (e) {
-        console.error("Failed to parse result as JSON:", e);
+        log.error('Failed to parse result as JSON', { error: (e as Error).message });
         return {
           success: false,
           error: `Failed to parse result: ${result}`
@@ -68,11 +73,12 @@ export async function getFolderById(params: GetFolderByIdParams): Promise<{succe
       };
     }
 
-  } catch (error: any) {
-    console.error("Error in getFolderById:", error);
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log.error('Error in getFolderById', { error: errorMsg });
     return {
       success: false,
-      error: error?.message || "Unknown error in getFolderById"
+      error: errorMsg || "Unknown error in getFolderById"
     };
   }
 }

--- a/src/tools/primitives/getForecastTasks.ts
+++ b/src/tools/primitives/getForecastTasks.ts
@@ -1,5 +1,6 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
 import { logger } from '../../utils/logger.js';
+import { formatDateSafe } from '../../utils/dateUtils.js';
 
 const log = logger.child('getForecastTasks');
 
@@ -73,7 +74,7 @@ export async function getForecastTasks(options: GetForecastTasksOptions = {}): P
               const statusStr = task.taskStatus !== 'Available' ? ` [${task.taskStatus}]` : '';
               const estimateStr = task.estimatedMinutes ? ` ⏱${task.estimatedMinutes}m` : '';
               const typeIndicator = task.isDue ? '📅' : '🚀'; // Due vs Deferred
-              const createdStr = task.createdDate ? ` (created: ${new Date(task.createdDate).toLocaleDateString()})` : '';
+              const createdStr = task.createdDate ? ` (created: ${formatDateSafe(task.createdDate)})` : '';
 
               output += `• ${typeIndicator} ${flagSymbol}${task.name}${projectStr}${statusStr}${estimateStr} [ID: ${task.id}]${createdStr}\n`;
               

--- a/src/tools/primitives/getInboxTasks.ts
+++ b/src/tools/primitives/getInboxTasks.ts
@@ -1,5 +1,6 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
 import { logger } from '../../utils/logger.js';
+import { formatDateSafe } from '../../utils/dateUtils.js';
 
 const log = logger.child('getInboxTasks');
 
@@ -39,9 +40,9 @@ export async function getInboxTasks(options: GetInboxTasksOptions = {}): Promise
           
           data.tasks.forEach((task: any, index: number) => {
             const flagSymbol = task.flagged ? '🚩 ' : '';
-            const dueDateStr = task.dueDate ? ` [DUE: ${new Date(task.dueDate).toLocaleDateString()}]` : '';
+            const dueDateStr = task.dueDate ? ` [DUE: ${formatDateSafe(task.dueDate)}]` : '';
             const statusStr = task.taskStatus !== 'Available' ? ` (${task.taskStatus})` : '';
-            const createdStr = task.createdDate ? ` (created: ${new Date(task.createdDate).toLocaleDateString()})` : '';
+            const createdStr = task.createdDate ? ` (created: ${formatDateSafe(task.createdDate)})` : '';
 
             output += `${index + 1}. ${flagSymbol}${task.name}${dueDateStr}${statusStr} [ID: ${task.id}]${createdStr}\n`;
             

--- a/src/tools/primitives/getPerspectiveTasksV2.ts
+++ b/src/tools/primitives/getPerspectiveTasksV2.ts
@@ -1,4 +1,7 @@
 import { PerspectiveEngine, TaskItem } from '../../utils/perspectiveEngine.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('getPerspectiveTasksV2');
 
 // Perspective access interface based on OmniFocus 4.2+ new API
 
@@ -32,8 +35,8 @@ export async function getPerspectiveTasksV2(
   params: GetPerspectiveTasksV2Params
 ): Promise<GetPerspectiveTasksV2Result> {
 
-  console.log(`[PerspectiveV2] Starting to get tasks for perspective "${params.perspectiveName}"`);
-  console.log(`[PerspectiveV2] Parameters:`, {
+  log.debug('Starting to get tasks for perspective', {
+    perspectiveName: params.perspectiveName,
     hideCompleted: params.hideCompleted,
     limit: params.limit
   });
@@ -49,26 +52,27 @@ export async function getPerspectiveTasksV2(
     });
 
     if (!result.success) {
-      console.error(`[PerspectiveV2] Execution failed:`, result.error);
+      log.error('Execution failed', { error: result.error });
       return {
         success: false,
         error: result.error
       };
     }
 
-    console.log(`[PerspectiveV2] Execution successful`);
-    console.log(`[PerspectiveV2] Perspective info:`, result.perspectiveInfo);
-    console.log(`[PerspectiveV2] Filtered ${result.tasks?.length || 0} tasks`);
+    log.debug('Execution successful', {
+      perspectiveInfo: result.perspectiveInfo,
+      taskCount: result.tasks?.length || 0
+    });
 
     // Log detailed task info for debugging
     if (result.tasks && result.tasks.length > 0) {
-      console.log(`[PerspectiveV2] Task sample:`, {
+      log.debug('Task sample', {
         first: {
           name: result.tasks[0].name,
           flagged: result.tasks[0].flagged,
           dueDate: result.tasks[0].dueDate,
           projectName: result.tasks[0].projectName,
-          tags: result.tasks[0].tags?.length || 0
+          tagCount: result.tasks[0].tags?.length || 0
         }
       });
     }
@@ -79,12 +83,13 @@ export async function getPerspectiveTasksV2(
       perspectiveInfo: result.perspectiveInfo
     };
 
-  } catch (error: any) {
-    console.error(`[PerspectiveV2] Perspective engine error:`, error);
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log.error('Perspective engine error', { error: errorMsg });
 
     return {
       success: false,
-      error: `Perspective engine error: ${error.message || 'Unknown error'}`
+      error: `Perspective engine error: ${errorMsg}`
     };
   }
 }

--- a/src/tools/primitives/getProjectById.ts
+++ b/src/tools/primitives/getProjectById.ts
@@ -1,4 +1,7 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('getProjectById');
 
 // Interface for project lookup parameters
 export interface GetProjectByIdParams {
@@ -42,8 +45,10 @@ export async function getProjectById(params: GetProjectByIdParams): Promise<{suc
       };
     }
 
-    console.error("Executing OmniJS script for getProjectById...");
-    console.error(`Parameters: projectId=${params.projectId}, projectName=${params.projectName}`);
+    log.debug('Executing OmniJS script for getProjectById', {
+      projectId: params.projectId,
+      projectName: params.projectName
+    });
 
     // Execute the OmniJS script
     const result = await executeOmniFocusScript('@getProjectByName.js', {
@@ -57,7 +62,7 @@ export async function getProjectById(params: GetProjectByIdParams): Promise<{suc
       try {
         parsed = JSON.parse(result);
       } catch (e) {
-        console.error("Failed to parse result as JSON:", e);
+        log.error('Failed to parse result as JSON', { error: (e as Error).message });
         return {
           success: false,
           error: `Failed to parse result: ${result}`
@@ -79,11 +84,12 @@ export async function getProjectById(params: GetProjectByIdParams): Promise<{suc
       };
     }
 
-  } catch (error: any) {
-    console.error("Error in getProjectById:", error);
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log.error('Error in getProjectById', { error: errorMsg });
     return {
       success: false,
-      error: error?.message || "Unknown error in getProjectById"
+      error: errorMsg || "Unknown error in getProjectById"
     };
   }
 }

--- a/src/tools/primitives/getProjectsForReview.ts
+++ b/src/tools/primitives/getProjectsForReview.ts
@@ -1,4 +1,7 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('getProjectsForReview');
 
 // Interface for get projects for review parameters
 export interface GetProjectsForReviewParams {
@@ -30,8 +33,10 @@ export async function getProjectsForReview(params: GetProjectsForReviewParams): 
   error?: string;
 }> {
   try {
-    console.error("Executing OmniJS script for getProjectsForReview...");
-    console.error(`Parameters: includeOnHold=${params.includeOnHold}, limit=${params.limit}`);
+    log.debug('Executing OmniJS script for getProjectsForReview', {
+      includeOnHold: params.includeOnHold,
+      limit: params.limit
+    });
 
     // Execute the OmniJS script
     const result = await executeOmniFocusScript('@getProjectsForReview.js', {
@@ -45,7 +50,7 @@ export async function getProjectsForReview(params: GetProjectsForReviewParams): 
       try {
         parsed = JSON.parse(result);
       } catch (e) {
-        console.error("Failed to parse result as JSON:", e);
+        log.error('Failed to parse result as JSON', { error: (e as Error).message });
         return {
           success: false,
           error: `Failed to parse result: ${result}`
@@ -69,11 +74,12 @@ export async function getProjectsForReview(params: GetProjectsForReviewParams): 
       };
     }
 
-  } catch (error: any) {
-    console.error("Error in getProjectsForReview:", error);
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log.error('Error in getProjectsForReview', { error: errorMsg });
     return {
       success: false,
-      error: error?.message || "Unknown error in getProjectsForReview"
+      error: errorMsg || "Unknown error in getProjectsForReview"
     };
   }
 }

--- a/src/tools/primitives/getTasksByTag.ts
+++ b/src/tools/primitives/getTasksByTag.ts
@@ -1,5 +1,6 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
 import { logger } from '../../utils/logger.js';
+import { formatDateSafe } from '../../utils/dateUtils.js';
 
 const log = logger.child('getTasksByTag');
 
@@ -112,11 +113,11 @@ export async function getTasksByTag(options: GetTasksByTagOptions): Promise<stri
             
             tasks.forEach((task: any) => {
               const flagSymbol = task.flagged ? '🚩 ' : '';
-              const dueDateStr = task.dueDate ? ` [DUE: ${new Date(task.dueDate).toLocaleDateString()}]` : '';
-              const deferDateStr = task.deferDate ? ` [DEFER: ${new Date(task.deferDate).toLocaleDateString()}]` : '';
+              const dueDateStr = task.dueDate ? ` [DUE: ${formatDateSafe(task.dueDate)}]` : '';
+              const deferDateStr = task.deferDate ? ` [DEFER: ${formatDateSafe(task.deferDate)}]` : '';
               const statusStr = task.taskStatus !== 'Available' ? ` (${task.taskStatus})` : '';
               const estimateStr = task.estimatedMinutes ? ` ⏱${task.estimatedMinutes}m` : '';
-              const createdStr = task.createdDate ? ` (created: ${new Date(task.createdDate).toLocaleDateString()})` : '';
+              const createdStr = task.createdDate ? ` (created: ${formatDateSafe(task.createdDate)})` : '';
 
               output += `• ${flagSymbol}${task.name}${dueDateStr}${deferDateStr}${statusStr}${estimateStr} [ID: ${task.id}]${createdStr}\n`;
               

--- a/src/tools/primitives/getTodayCompletedTasks.ts
+++ b/src/tools/primitives/getTodayCompletedTasks.ts
@@ -1,4 +1,7 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('getTodayCompletedTasks');
 
 export interface GetTodayCompletedTasksOptions {
   limit?: number;
@@ -71,7 +74,7 @@ export async function getTodayCompletedTasks(options: GetTodayCompletedTasksOpti
     return "Unable to parse OmniFocus result";
     
   } catch (error) {
-    console.error("Error in getTodayCompletedTasks:", error);
+    log.error('Error in getTodayCompletedTasks', { error: error instanceof Error ? error.message : String(error) });
     throw new Error(`Failed to get today's completed tasks: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
 }

--- a/src/tools/primitives/listCustomPerspectives.ts
+++ b/src/tools/primitives/listCustomPerspectives.ts
@@ -1,4 +1,7 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('listCustomPerspectives');
 
 export interface ListCustomPerspectivesOptions {
   format?: 'simple' | 'detailed';
@@ -8,31 +11,30 @@ export async function listCustomPerspectives(options: ListCustomPerspectivesOpti
   const { format = 'simple' } = options;
   
   try {
-    console.log('Starting listCustomPerspectives script...');
+    log.debug('Starting listCustomPerspectives script');
 
     // Execute the list custom perspectives script
     const result = await executeOmniFocusScript('@listCustomPerspectives.js', {});
 
-    console.log('Script execution complete, result type:', typeof result);
-    console.log('Script result:', result);
+    log.debug('Script execution complete', { resultType: typeof result });
 
     // Handle various return types
     let data: any;
 
     if (typeof result === 'string') {
-      console.log('Result is string, attempting JSON parse...');
+      log.debug('Result is string, attempting JSON parse');
       try {
         data = JSON.parse(result);
-        console.log('JSON parse successful:', data);
+        log.debug('JSON parse successful');
       } catch (parseError) {
-        console.error('JSON parse failed:', parseError);
+        log.error('JSON parse failed', { error: (parseError as Error).message });
         throw new Error(`Failed to parse string result: ${result}`);
       }
     } else if (typeof result === 'object' && result !== null) {
-      console.log('Result is object, using directly...');
+      log.debug('Result is object, using directly');
       data = result;
     } else {
-      console.error('Invalid result type:', typeof result, result);
+      log.error('Invalid result type', { type: typeof result, value: result });
       throw new Error(`Script returned invalid result type: ${typeof result}, value: ${result}`);
     }
 
@@ -59,7 +61,7 @@ export async function listCustomPerspectives(options: ListCustomPerspectivesOpti
     }
 
   } catch (error) {
-    console.error('Error in listCustomPerspectives:', error);
+    log.error('Error in listCustomPerspectives', { error: error instanceof Error ? error.message : String(error) });
     return `❌ **Error**: ${error instanceof Error ? error.message : String(error)}`;
   }
 }

--- a/src/tools/primitives/listProjects.ts
+++ b/src/tools/primitives/listProjects.ts
@@ -1,4 +1,7 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('listProjects');
 
 export interface ListProjectsOptions {
   folderName?: string;
@@ -37,8 +40,12 @@ export async function listProjects(options: ListProjectsOptions = {}): Promise<L
   } = options;
 
   try {
-    console.error("Executing OmniJS script for listProjects...");
-    console.error(`Parameters: folderName=${folderName}, folderId=${folderId}, status=${status}, limit=${limit}`);
+    log.debug('Executing OmniJS script for listProjects', {
+      folderName,
+      folderId,
+      status,
+      limit
+    });
 
     const result = await executeOmniFocusScript('@listProjects.js', {
       folderName,
@@ -54,7 +61,7 @@ export async function listProjects(options: ListProjectsOptions = {}): Promise<L
       try {
         parsed = JSON.parse(result);
       } catch (e) {
-        console.error("Failed to parse result as JSON:", e);
+        log.error('Failed to parse result as JSON', { error: (e as Error).message });
         return {
           success: false,
           error: `Failed to parse result: ${result}`,
@@ -70,11 +77,12 @@ export async function listProjects(options: ListProjectsOptions = {}): Promise<L
 
     return parsed;
 
-  } catch (error: any) {
-    console.error("Error in listProjects:", error);
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log.error('Error in listProjects', { error: errorMsg });
     return {
       success: false,
-      error: error?.message || "Unknown error in listProjects",
+      error: errorMsg || "Unknown error in listProjects",
       count: 0,
       folderFilter: null,
       statusFilter: status,

--- a/src/tools/primitives/listTags.ts
+++ b/src/tools/primitives/listTags.ts
@@ -1,4 +1,7 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('listTags');
 
 export interface ListTagsOptions {
   includeDropped?: boolean;
@@ -100,7 +103,7 @@ export async function listTags(options: ListTagsOptions = {}): Promise<string> {
     return output;
 
   } catch (error) {
-    console.error("Error in listTags:", error);
+    log.error('Error in listTags', { error: error instanceof Error ? error.message : String(error) });
     throw new Error(`Failed to list tags: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
 }

--- a/src/tools/primitives/searchTasks.ts
+++ b/src/tools/primitives/searchTasks.ts
@@ -1,6 +1,7 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
 import { queryCache } from '../../utils/cache.js';
 import { logger } from '../../utils/logger.js';
+import { formatDateSafe } from '../../utils/dateUtils.js';
 
 const log = logger.child('searchTasks');
 
@@ -153,13 +154,14 @@ function formatSearchResults(data: SearchResult, query: string, matchMode: strin
       output += `- ${flagSymbol}${task.name} ${matchIndicator}`;
       output += ` [ID: ${task.id}]`;
 
-      if (task.dueDate) {
-        const dueDateStr = new Date(task.dueDate).toLocaleDateString();
+      const dueDateStr = formatDateSafe(task.dueDate);
+      if (dueDateStr) {
         output += ` [📅 ${dueDateStr}]`;
       }
 
-      if (task.createdDate) {
-        output += ` (created: ${new Date(task.createdDate).toLocaleDateString()})`;
+      const createdDateStr = formatDateSafe(task.createdDate);
+      if (createdDateStr) {
+        output += ` (created: ${createdDateStr})`;
       }
 
       output += '\n';


### PR DESCRIPTION
## Summary

- **Issue #81**: Extended `formatDateSafe()` to all 8 primitive files (21 instances), preventing "Invalid Date" strings in output
- **Issue #82**: Migrated 10 primitives from `console.error` to structured `logger` utility with consistent format

## Changes

### Issue #81 - Safe Date Formatting
| File | Instances | Date Fields |
|------|-----------|-------------|
| filterTasks.ts | 5 | createdDate, dueDate, deferDate, plannedDate, completedDate |
| getCustomPerspectiveTasks.ts | 4 | dueDate x2, createdDate x2 |
| batchFilterTasks.ts | 3 | createdDate, dueDate, deferDate |
| getFlaggedTasks.ts | 3 | dueDate, deferDate, createdDate |
| getTasksByTag.ts | 3 | dueDate, deferDate, createdDate |
| searchTasks.ts | 2 | dueDate, createdDate |
| getInboxTasks.ts | 2 | dueDate, createdDate |
| getForecastTasks.ts | 1 | createdDate |

### Issue #82 - Logging Standardization
- batchFilterTasks.ts, getCustomPerspectiveTasks.ts, getFolderById.ts
- getPerspectiveTasksV2.ts, getProjectById.ts, getProjectsForReview.ts
- getTodayCompletedTasks.ts, listCustomPerspectives.ts, listProjects.ts, listTags.ts

## Test plan

- [ ] Verify build succeeds (`npm run build`)
- [ ] Grep confirms no remaining `new Date(...).toLocaleDateString()` in primitives
- [ ] All 8 date-formatting files import `formatDateSafe`
- [ ] All logging files use `logger.child()` pattern

Closes #81, Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)