### PR TITLE
fix: Complete logging standardization across codebase (Issue #84)

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,27 @@
-# OmniFocus MCP Server - What's New (v1.29.2)
+# OmniFocus MCP Server - What's New (v1.29.3)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.29.3 Complete Logging Standardization (Issue #84)
+
+**Extended structured logging to ALL remaining files:**
+
+### Primitive files (11 files)
+- Standardized `catch (error: any)` to `catch (error)` with `instanceof Error` pattern
+- Files: `addOmniFocusTask.ts`, `addProject.ts`, `addFolder.ts`, `getTaskById.ts`, `removeItem.ts`, `editItem.ts`, `batchAddItems.ts`, `batchEditItems.ts`, `batchRemoveItems.ts`, `batchMarkReviewed.ts`, `diagnoseConnection.ts`
+
+### perspectiveEngine.ts
+- Migrated all TypeScript-level console statements to structured logger
+- JXA script console statements (which run inside OmniFocus) left unchanged
+- Added `logger.child('perspectiveEngine')` with consistent debug/error patterns
+
+### Definition files (11 files)
+- Added logger imports and replaced `console.error` with `log.error`
+- Files: `getFolderById.ts`, `addFolder.ts`, `getProjectsForReview.ts`, `batchMarkReviewed.ts`, `batchRemoveItems.ts`, `removeItem.ts`, `getTaskById.ts`, `getProjectById.ts`, `editItem.ts`, `batchEditItems.ts`, `getPerspectiveTasksV2.ts`
+
+**Result:** No more `console.log` or `console.error` in TypeScript code (except JXA scripts). All logging goes through structured logger to stderr.
+
+---
 
 ## v1.29.2 Logging Standardization
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.29.2",
+  "version": "1.29.3",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/tools/definitions/addFolder.ts
+++ b/src/tools/definitions/addFolder.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 import { addFolder, AddFolderParams } from '../primitives/addFolder.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('def:addFolder');
 
 export const schema = z.object({
   name: z.string().describe("The name of the folder to create"),
@@ -38,7 +41,7 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
     }
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    console.error(`Tool execution error: ${errorMessage}`);
+    log.error('Tool execution error', { error: errorMessage });
     return {
       content: [{
         type: "text" as const,

--- a/src/tools/definitions/batchEditItems.ts
+++ b/src/tools/definitions/batchEditItems.ts
@@ -3,6 +3,9 @@ import { batchEditItems, BatchEditItemParams } from '../primitives/batchEditItem
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
 import { repetitionRuleSchema } from '../../schemas/repetitionRule.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('def:batchEditItems');
 
 // Schema for a single edit operation
 const editItemSchema = z.object({
@@ -98,7 +101,7 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
     }
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    console.error(`Tool execution error: ${errorMessage}`);
+    log.error('Tool execution error', { error: errorMessage });
     return {
       content: [{
         type: "text" as const,

--- a/src/tools/definitions/batchMarkReviewed.ts
+++ b/src/tools/definitions/batchMarkReviewed.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 import { batchMarkReviewed, BatchMarkReviewedParams } from '../primitives/batchMarkReviewed.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('def:batchMarkReviewed');
 
 export const schema = z.object({
   projectIds: z.array(z.string()).optional().describe("Array of project IDs to mark as reviewed"),
@@ -92,7 +95,7 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
     }
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    console.error(`Tool execution error: ${errorMessage}`);
+    log.error('Tool execution error', { error: errorMessage });
     return {
       content: [{
         type: "text" as const,

--- a/src/tools/definitions/batchRemoveItems.ts
+++ b/src/tools/definitions/batchRemoveItems.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 import { batchRemoveItems, BatchRemoveItemsParams } from '../primitives/batchRemoveItems.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('def:batchRemoveItems');
 
 export const schema = z.object({
   items: z.array(z.object({
@@ -66,7 +69,7 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
     }
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    console.error(`Tool execution error: ${errorMessage}`);
+    log.error('Tool execution error', { error: errorMessage });
     return {
       content: [{
         type: "text" as const,

--- a/src/tools/definitions/editItem.ts
+++ b/src/tools/definitions/editItem.ts
@@ -3,6 +3,9 @@ import { editItem, EditItemParams } from '../primitives/editItem.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
 import { repetitionRuleSchema } from '../../schemas/repetitionRule.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('def:editItem');
 
 export const schema = z.object({
   id: z.string().optional().describe("The ID of the task or project to edit"),
@@ -103,7 +106,7 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
     }
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    console.error(`Tool execution error: ${errorMessage}`);
+    log.error('Tool execution error', { error: errorMessage });
 
     return {
       content: [{

--- a/src/tools/definitions/getFolderById.ts
+++ b/src/tools/definitions/getFolderById.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 import { getFolderById, GetFolderByIdParams } from '../primitives/getFolderById.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('def:getFolderById');
 
 export const schema = z.object({
   folderId: z.string().optional().describe("The ID of the folder to retrieve"),
@@ -58,7 +61,7 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
     }
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    console.error(`Tool execution error: ${errorMessage}`);
+    log.error('Tool execution error', { error: errorMessage });
     return {
       content: [{
         type: "text" as const,

--- a/src/tools/definitions/getPerspectiveTasksV2.ts
+++ b/src/tools/definitions/getPerspectiveTasksV2.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 import { getPerspectiveTasksV2 } from '../primitives/getPerspectiveTasksV2.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('def:getPerspectiveTasksV2');
 
 // Native perspective access tool based on OmniFocus 4.2+ API
 // Differences from the original get_custom_perspective tool:
@@ -71,14 +74,15 @@ export async function handler(params: GetPerspectiveTasksV2Params) {
       }]
     };
 
-  } catch (error: any) {
-    console.error('getPerspectiveTasksV2 handler error:', error);
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log.error('getPerspectiveTasksV2 handler error', { error: errorMsg });
     return {
       content: [{
         type: "text" as const,
         text: JSON.stringify({
           success: false,
-          error: error.message || 'Unknown error in getPerspectiveTasksV2',
+          error: errorMsg || 'Unknown error in getPerspectiveTasksV2',
           metadata: {
             timestamp: new Date().toISOString(),
             apiVersion: "v2",

--- a/src/tools/definitions/getProjectById.ts
+++ b/src/tools/definitions/getProjectById.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 import { getProjectById, GetProjectByIdParams } from '../primitives/getProjectById.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('def:getProjectById');
 
 export const schema = z.object({
   projectId: z.string().optional().describe("The ID of the project to retrieve"),
@@ -90,7 +93,7 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
     }
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    console.error(`Tool execution error: ${errorMessage}`);
+    log.error('Tool execution error', { error: errorMessage });
     return {
       content: [{
         type: "text" as const,

--- a/src/tools/definitions/getProjectsForReview.ts
+++ b/src/tools/definitions/getProjectsForReview.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 import { getProjectsForReview, GetProjectsForReviewParams } from '../primitives/getProjectsForReview.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('def:getProjectsForReview');
 
 export const schema = z.object({
   includeOnHold: z.boolean().optional().describe("Include on-hold projects in results (default: false)"),
@@ -69,7 +72,7 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
     }
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    console.error(`Tool execution error: ${errorMessage}`);
+    log.error('Tool execution error', { error: errorMessage });
     return {
       content: [{
         type: "text" as const,

--- a/src/tools/definitions/getTaskById.ts
+++ b/src/tools/definitions/getTaskById.ts
@@ -3,6 +3,9 @@ import { getTaskById, GetTaskByIdParams } from '../primitives/getTaskById.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
 import { formatDateSafe } from '../../utils/dateUtils.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('def:getTaskById');
 
 export const schema = z.object({
   taskId: z.string().optional().describe("The ID of the task to retrieve"),
@@ -89,7 +92,7 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
     }
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    console.error(`Tool execution error: ${errorMessage}`);
+    log.error('Tool execution error', { error: errorMessage });
     return {
       content: [{
         type: "text" as const,

--- a/src/tools/definitions/removeItem.ts
+++ b/src/tools/definitions/removeItem.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 import { removeItem, RemoveItemParams } from '../primitives/removeItem.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('def:removeItem');
 
 export const schema = z.object({
   id: z.string().optional().describe("The ID of the task or project to remove"),
@@ -34,7 +37,7 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
     }
     
     // Log the remove operation for debugging
-    console.error(`Removing ${args.itemType} with ID: ${args.id || 'not provided'}, Name: ${args.name || 'not provided'}`);
+    log.debug('Removing item', { itemType: args.itemType, id: args.id || 'not provided', name: args.name || 'not provided' });
     
     // Call the removeItem function 
     const result = await removeItem(args as RemoveItemParams);
@@ -74,7 +77,7 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
     }
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    console.error(`Tool execution error: ${errorMessage}`);
+    log.error('Tool execution error', { error: errorMessage });
 
     return {
       content: [{

--- a/src/tools/primitives/addFolder.ts
+++ b/src/tools/primitives/addFolder.ts
@@ -64,11 +64,12 @@ export async function addFolder(params: AddFolderParams): Promise<{success: bool
       };
     }
 
-  } catch (error: any) {
-    log.error('Error in addFolder', { error: error?.message });
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log.error('Error in addFolder', { error: errorMsg });
     return {
       success: false,
-      error: error?.message || "Unknown error in addFolder"
+      error: errorMsg || "Unknown error in addFolder"
     };
   }
 }

--- a/src/tools/primitives/addOmniFocusTask.ts
+++ b/src/tools/primitives/addOmniFocusTask.ts
@@ -131,11 +131,12 @@ export async function addOmniFocusTask(params: AddOmniFocusTaskParams): Promise<
       };
     }
 
-  } catch (error: any) {
-    log.error('Error in addOmniFocusTask', { error: error?.message });
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log.error('Error in addOmniFocusTask', { error: errorMsg });
     return {
       success: false,
-      error: error?.message || "Unknown error in addOmniFocusTask"
+      error: errorMsg || "Unknown error in addOmniFocusTask"
     };
   }
 }

--- a/src/tools/primitives/addProject.ts
+++ b/src/tools/primitives/addProject.ts
@@ -79,11 +79,12 @@ export async function addProject(params: AddProjectParams): Promise<{success: bo
       };
     }
 
-  } catch (error: any) {
-    log.error('Error in addProject', { error: error?.message });
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log.error('Error in addProject', { error: errorMsg });
     return {
       success: false,
-      error: error?.message || "Unknown error in addProject"
+      error: errorMsg || "Unknown error in addProject"
     };
   }
 }

--- a/src/tools/primitives/batchAddItems.ts
+++ b/src/tools/primitives/batchAddItems.ts
@@ -178,18 +178,18 @@ export async function batchAddItems(items: BatchAddItemsParams[]): Promise<Batch
       error: parsed.error
     };
 
-  } catch (error: any) {
+  } catch (error) {
     // Handle both StructuredError and regular Error
     const errorMessage = isStructuredError(error)
       ? error.error.message
-      : (error?.message || "Unknown error in batchAddItems");
+      : (error instanceof Error ? error.message : String(error));
     log.error('Error in batchAddItems', { error: errorMessage });
     return {
       success: false,
       successCount: 0,
       failureCount: items.length,
       results: [],
-      error: errorMessage
+      error: errorMessage || "Unknown error in batchAddItems"
     };
   }
 }

--- a/src/tools/primitives/batchEditItems.ts
+++ b/src/tools/primitives/batchEditItems.ts
@@ -118,14 +118,15 @@ export async function batchEditItems(edits: BatchEditItemParams[]): Promise<Batc
       error: parsed.error
     };
 
-  } catch (error: any) {
-    log.error('Error in batchEditItems', { error: error?.message });
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log.error('Error in batchEditItems', { error: errorMsg });
     return {
       success: false,
       successCount: 0,
       failureCount: edits.length,
       results: [],
-      error: error?.message || "Unknown error in batchEditItems"
+      error: errorMsg || "Unknown error in batchEditItems"
     };
   }
 }

--- a/src/tools/primitives/batchMarkReviewed.ts
+++ b/src/tools/primitives/batchMarkReviewed.ts
@@ -82,11 +82,12 @@ export async function batchMarkReviewed(params: BatchMarkReviewedParams): Promis
       error: parsed.error
     };
 
-  } catch (error: any) {
-    log.error('Error in batchMarkReviewed', { error: error?.message });
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log.error('Error in batchMarkReviewed', { error: errorMsg });
     return {
       success: false,
-      error: error?.message || "Unknown error in batchMarkReviewed"
+      error: errorMsg || "Unknown error in batchMarkReviewed"
     };
   }
 }

--- a/src/tools/primitives/batchRemoveItems.ts
+++ b/src/tools/primitives/batchRemoveItems.ts
@@ -81,14 +81,15 @@ export async function batchRemoveItems(items: BatchRemoveItemsParams[]): Promise
       error: parsed.error
     };
 
-  } catch (error: any) {
-    log.error('Error in batchRemoveItems', { error: error?.message });
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log.error('Error in batchRemoveItems', { error: errorMsg });
     return {
       success: false,
       successCount: 0,
       failureCount: items.length,
       results: [],
-      error: error?.message || "Unknown error in batchRemoveItems"
+      error: errorMsg || "Unknown error in batchRemoveItems"
     };
   }
 }

--- a/src/tools/primitives/diagnoseConnection.ts
+++ b/src/tools/primitives/diagnoseConnection.ts
@@ -64,8 +64,9 @@ export async function diagnoseConnection(): Promise<DiagnosticResult> {
       errors.push(`Script error: ${parsed.error}`);
     }
 
-  } catch (error: any) {
-    const message = error.message?.toLowerCase() || '';
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    const message = errorMsg.toLowerCase();
 
     if (message.includes('timed out')) {
       errors.push('Script execution timed out');
@@ -86,7 +87,7 @@ export async function diagnoseConnection(): Promise<DiagnosticResult> {
       errors.push('OmniFocus is not running');
       instructions.push('Start OmniFocus and try again');
     } else {
-      errors.push(`Unknown error: ${error.message}`);
+      errors.push(`Unknown error: ${errorMsg}`);
       instructions.push(
         'Check that OmniFocus is installed and running.',
         'Ensure automation permissions are granted.',

--- a/src/tools/primitives/editItem.ts
+++ b/src/tools/primitives/editItem.ts
@@ -139,11 +139,12 @@ export async function editItem(params: EditItemParams): Promise<{
       };
     }
 
-  } catch (error: any) {
-    log.error('Error in editItem', { error: error?.message });
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log.error('Error in editItem', { error: errorMsg });
     return {
       success: false,
-      error: error?.message || "Unknown error in editItem"
+      error: errorMsg || "Unknown error in editItem"
     };
   }
 }

--- a/src/tools/primitives/getTaskById.ts
+++ b/src/tools/primitives/getTaskById.ts
@@ -86,11 +86,12 @@ export async function getTaskById(params: GetTaskByIdParams): Promise<{success: 
 
     return response;
 
-  } catch (error: any) {
-    log.error('Error in getTaskById', { error: error?.message });
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log.error('Error in getTaskById', { error: errorMsg });
     return {
       success: false,
-      error: error?.message || "Unknown error in getTaskById"
+      error: errorMsg || "Unknown error in getTaskById"
     };
   }
 }

--- a/src/tools/primitives/removeItem.ts
+++ b/src/tools/primitives/removeItem.ts
@@ -65,11 +65,12 @@ export async function removeItem(params: RemoveItemParams): Promise<{success: bo
       };
     }
 
-  } catch (error: any) {
-    log.error('Error in removeItem', { error: error?.message });
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    log.error('Error in removeItem', { error: errorMsg });
     return {
       success: false,
-      error: error?.message || "Unknown error in removeItem"
+      error: errorMsg || "Unknown error in removeItem"
     };
   }
 }

--- a/src/utils/perspectiveEngine.ts
+++ b/src/utils/perspectiveEngine.ts
@@ -1,4 +1,7 @@
 import { executeJXA } from './scriptExecution.js';
+import { logger } from './logger.js';
+
+const log = logger.child('perspectiveEngine');
 
 // OmniFocus Perspective Engine - Based on 4.2+ new API
 // Supports true perspective filtering, not full data return like AppleScript
@@ -92,7 +95,7 @@ export class PerspectiveEngine {
   }> {
     try {
       // Get filtered tasks directly from OmniFocus perspective
-      console.log(`[DEBUG] Getting tasks from OmniFocus perspective "${perspectiveName}"...`);
+      log.debug('Getting tasks from OmniFocus perspective', { perspectiveName });
       const filteredTasks = await this.getTasksFromPerspective(perspectiveName);
 
       // Apply additional option filters
@@ -115,11 +118,12 @@ export class PerspectiveEngine {
         }
       };
 
-    } catch (error: any) {
-      console.error('Perspective engine execution error:', error);
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      log.error('Perspective engine execution error', { error: errorMsg });
       return {
         success: false,
-        error: error.message || 'Perspective engine execution failed'
+        error: errorMsg || 'Perspective engine execution failed'
       };
     }
   }
@@ -173,7 +177,8 @@ export class PerspectiveEngine {
       }
       return { supportsNewAPI: false };
     } catch (error) {
-      console.error('Version check failed:', error);
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      log.error('Version check failed', { error: errorMsg });
       return { supportsNewAPI: false };
     }
   }
@@ -248,13 +253,14 @@ export class PerspectiveEngine {
       }
 
       if (parsed.error) {
-        console.error('Failed to get perspective config:', parsed.error);
+        log.error('Failed to get perspective config', { error: parsed.error });
         return null;
       }
 
       return parsed;
     } catch (error) {
-      console.error('Perspective config execution failed:', error);
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      log.error('Perspective config execution failed', { error: errorMsg });
       return null;
     }
   }
@@ -338,27 +344,26 @@ export class PerspectiveEngine {
     `;
 
     try {
-      console.log(`[DEBUG] Getting tasks from perspective "${perspectiveName}"...`);
+      log.debug('Getting tasks from perspective', { perspectiveName });
       const result = await executeJXA(script);
-      console.log('[DEBUG] Perspective query result type:', typeof result);
-      console.log('[DEBUG] Perspective query result:', JSON.stringify(result).substring(0, 200));
+      log.debug('Perspective query result', { resultType: typeof result, preview: JSON.stringify(result).substring(0, 200) });
 
       // Simplified handling: executeJXA should return task array directly
       let tasks = result;
 
       // Check for errors
       if (tasks && typeof tasks === 'object' && !Array.isArray(tasks) && (tasks as any).error) {
-        console.error('Perspective query error:', (tasks as any).error);
+        log.error('Perspective query error', { error: (tasks as any).error });
         return [];
       }
 
       // Ensure it's an array
       if (!Array.isArray(tasks)) {
-        console.log('[DEBUG] Perspective query result is not array, type:', typeof tasks);
+        log.debug('Perspective query result is not array', { resultType: typeof tasks });
         return [];
       }
 
-      console.log(`[DEBUG] Successfully got ${tasks.length} tasks from perspective`);
+      log.debug('Successfully got tasks from perspective', { taskCount: tasks.length });
 
       // Build tag cache
       this.buildTagCache(tasks);
@@ -366,7 +371,8 @@ export class PerspectiveEngine {
       // Convert to standard format
       return tasks.map((task: any) => this.normalizeTask(task));
     } catch (error) {
-      console.error('Failed to get tasks from perspective:', error);
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      log.error('Failed to get tasks from perspective', { error: errorMsg });
       return [];
     }
   }
@@ -421,27 +427,26 @@ export class PerspectiveEngine {
     `;
 
     try {
-      console.log('[DEBUG] Executing JXA script...');
+      log.debug('Executing JXA script for getAllTasks');
       const result = await executeJXA(script);
-      console.log('[DEBUG] JXA script result type:', typeof result);
-      console.log('[DEBUG] JXA script result:', JSON.stringify(result).substring(0, 200));
+      log.debug('JXA script result', { resultType: typeof result, preview: JSON.stringify(result).substring(0, 200) });
 
       // Simplified handling: executeJXA should return task array directly
       let tasks = result;
 
       // Check for errors
       if (tasks && typeof tasks === 'object' && !Array.isArray(tasks) && (tasks as any).error) {
-        console.error('Script execution error:', (tasks as any).error);
+        log.error('Script execution error', { error: (tasks as any).error });
         return [];
       }
 
       // Ensure it's an array
       if (!Array.isArray(tasks)) {
-        console.log('[DEBUG] Result is not array, type:', typeof tasks);
+        log.debug('Result is not array', { resultType: typeof tasks });
         return [];
       }
 
-      console.log(`[DEBUG] Successfully parsed ${tasks.length} tasks`);
+      log.debug('Successfully parsed tasks', { taskCount: tasks.length });
 
       // Build tag cache
       this.buildTagCache(tasks);
@@ -449,7 +454,8 @@ export class PerspectiveEngine {
       // Convert to standard format
       return tasks.map((task: any) => this.normalizeTask(task));
     } catch (error) {
-      console.error('Failed to get all tasks:', error);
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      log.error('Failed to get all tasks', { error: errorMsg });
       return [];
     }
   }


### PR DESCRIPTION
## Summary

Completes the logging standardization work started in Issue #82, addressing all remaining files identified in the PR #83 review.

## Changes

### Primitive files (11 files)
| File | Change |
|------|--------|
| `addOmniFocusTask.ts` | `catch (error: any)` → `instanceof Error` pattern |
| `addProject.ts` | `catch (error: any)` → `instanceof Error` pattern |
| `addFolder.ts` | `catch (error: any)` → `instanceof Error` pattern |
| `getTaskById.ts` | `catch (error: any)` → `instanceof Error` pattern |
| `removeItem.ts` | `catch (error: any)` → `instanceof Error` pattern |
| `editItem.ts` | `catch (error: any)` → `instanceof Error` pattern |
| `batchAddItems.ts` | `catch (error: any)` → `instanceof Error` pattern |
| `batchEditItems.ts` | `catch (error: any)` → `instanceof Error` pattern |
| `batchRemoveItems.ts` | `catch (error: any)` → `instanceof Error` pattern |
| `batchMarkReviewed.ts` | `catch (error: any)` → `instanceof Error` pattern |
| `diagnoseConnection.ts` | `catch (error: any)` → `instanceof Error` pattern |

### perspectiveEngine.ts
- Migrated all TypeScript-level `console.log`/`console.error` to structured logger
- JXA script console statements (which run inside OmniFocus context) left unchanged
- Added `logger.child('perspectiveEngine')` with consistent debug/error patterns

### Definition files (11 files)
- Added logger imports and replaced `console.error` with `log.error`
- Files: `getFolderById`, `addFolder`, `getProjectsForReview`, `batchMarkReviewed`, `batchRemoveItems`, `removeItem`, `getTaskById`, `getProjectById`, `editItem`, `batchEditItems`, `getPerspectiveTasksV2`

## Test plan

- [x] `npm run build` passes
- [x] No `console.log`/`console.error` in TypeScript code (verified via grep)
- [x] JXA scripts preserved (they run inside OmniFocus, not Node.js)

## Result

All TypeScript logging now goes through the structured logger utility to stderr. Benefits:
- Consistent log format across entire codebase
- Log level filtering via `LOG_LEVEL` environment variable
- No risk of stdout corruption in MCP protocol

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)