### PR TITLE
fix: Add newFolderId support to batch_edit_items (Issue #90)

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,28 @@
-# OmniFocus MCP Server - What's New (v1.29.6)
+# OmniFocus MCP Server - What's New (v1.29.7)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.29.7 Fix batch_edit_items newFolderId Support (Issue #90)
+
+**Fixed `batch_edit_items` silently ignoring `newFolderId` parameter:**
+- Previously, using `newFolderId` to move projects was silently ignored
+- Now correctly moves projects to the specified folder by ID
+- ID lookup takes priority over name lookup (matches `edit_item` behavior)
+
+**Behavior note:**
+- `newFolderId` not found → Error (folders aren't auto-created by ID)
+- `newFolderName` not found → Creates new folder (existing behavior preserved)
+
+**Example:**
+```json
+{
+  "edits": [
+    {"itemType": "project", "id": "proj123", "newFolderId": "folder456"}
+  ]
+}
+```
+
+---
 
 ## v1.29.6 Fix batch_edit_items newProjectId Support (Issue #88)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.29.6",
+  "version": "1.29.7",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/tools/definitions/batchEditItems.ts
+++ b/src/tools/definitions/batchEditItems.ts
@@ -41,7 +41,8 @@ const editItemSchema = z.object({
 
   // Project-specific fields
   newSequential: z.boolean().optional().describe("Whether the project should be sequential"),
-  newFolderName: z.string().optional().describe("New folder to move the project to"),
+  newFolderName: z.string().optional().describe("Move project to a different folder (by name)"),
+  newFolderId: z.string().optional().describe("Move project to a different folder (by ID)"),
   newProjectStatus: z.enum(['active', 'completed', 'dropped', 'onHold']).optional().describe("New status for projects"),
 
   // Project review fields

--- a/src/tools/primitives/batchEditItems.ts
+++ b/src/tools/primitives/batchEditItems.ts
@@ -42,6 +42,7 @@ export interface BatchEditItemParams {
   // Project-specific fields
   newSequential?: boolean;
   newFolderName?: string;
+  newFolderId?: string;
   newProjectStatus?: ProjectStatus;
 
   // Project review fields

--- a/src/utils/omnifocusScripts/batchEditItems.js
+++ b/src/utils/omnifocusScripts/batchEditItems.js
@@ -42,6 +42,7 @@
     let tasksById = null;
     let tagsByName = null;
     let foldersByName = null;
+    let foldersById = null;
 
     function getProjectsByName() {
       if (!projectsByName) {
@@ -93,6 +94,14 @@
         flattenedFolders.forEach(f => foldersByName.set(f.name.toLowerCase(), f));
       }
       return foldersByName;
+    }
+
+    function getFoldersById() {
+      if (!foldersById) {
+        foldersById = new Map();
+        flattenedFolders.forEach(f => foldersById.set(f.id.primaryKey, f));
+      }
+      return foldersById;
     }
 
     const results = [];
@@ -336,9 +345,20 @@
           changedProperties.push("status");
         }
 
-        // Project-specific: Move to folder
-        if (itemType === 'project' && edit.newFolderName) {
-          const targetFolder = getFoldersByName().get(edit.newFolderName.toLowerCase());
+        // Project-specific: Move to folder (ID takes priority over name)
+        if (itemType === 'project' && (edit.newFolderId || edit.newFolderName)) {
+          let targetFolder = null;
+
+          // Try ID first
+          if (edit.newFolderId) {
+            targetFolder = getFoldersById().get(edit.newFolderId);
+          }
+
+          // Fall back to name if ID not found or not provided
+          if (!targetFolder && edit.newFolderName) {
+            targetFolder = getFoldersByName().get(edit.newFolderName.toLowerCase());
+          }
+
           if (targetFolder) {
             const currentFolder = foundItem.parentFolder;
             if (currentFolder && currentFolder.id.primaryKey === targetFolder.id.primaryKey) {
@@ -347,7 +367,17 @@
               moveSections([foundItem], targetFolder);
               changedProperties.push("moved to folder");
             }
+          } else if (edit.newFolderId) {
+            // ID was provided but not found - error
+            results.push({
+              success: false,
+              id: originalId,
+              name: originalName,
+              error: `Folder not found with ID "${edit.newFolderId}"`
+            });
+            continue;
           } else {
+            // Name was provided but not found - create new folder
             const newFolder = new Folder(edit.newFolderName);
             moveSections([foundItem], newFolder);
             changedProperties.push("moved to new folder");


### PR DESCRIPTION
## Summary
- Adds `newFolderId` parameter to `batch_edit_items` tool
- Fixes silent failure when moving projects to folders using folder ID
- ID lookup takes priority over name lookup (matches `edit_item` behavior)

## Root Cause
Same pattern as Issue #88: `batch_edit_items` was missing `newFolderId` support at 3 levels:
1. Schema - missing from Zod schema
2. Interface - missing from `BatchEditItemParams`
3. OmniJS - script only checked `newFolderName`

## Changes
| File | Change |
|------|--------|
| `src/tools/definitions/batchEditItems.ts` | Added `newFolderId` to schema |
| `src/tools/primitives/batchEditItems.ts` | Added `newFolderId` to interface |
| `src/utils/omnifocusScripts/batchEditItems.js` | Added `getFoldersById()` + updated logic |
| `package.json` | Bumped to 1.29.7 |
| `docs/WHATS_NEW.md` | Documented fix |

## Behavior Note
- `newFolderId` not found → Error (folders aren't auto-created by ID)
- `newFolderName` not found → Creates new folder (existing behavior preserved)

## Test plan
- [ ] Get a folder ID: `get_folder_by_id { "folderName": "some-folder" }`
- [ ] Move project using `newFolderId`: `batch_edit_items { "edits": [{"itemType": "project", "id": "<project-id>", "newFolderId": "<folder-id>"}] }`
- [ ] Verify response shows "moved to folder" (not "no changes")

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)