### PR TITLE
fix: Standardize error handling with type guards (Issue #86)

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,17 @@
-# OmniFocus MCP Server - What's New (v1.30.0)
+# OmniFocus MCP Server - What's New (v1.30.1)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.30.1 Type-Safe Error Handling (Issue #86)
+
+**Internal improvement: Standardized error handling with type guards**
+
+- Replaced `catch (error: any)` patterns with type-safe `catch (error)` using proper type guards
+- Added `isExecException` type guard for Node.js `ExecException` properties (`killed`, `signal`, `stderr`)
+- Updated `categorizeError` to accept `unknown` instead of `any`
+- No functional changes - this is a TypeScript strictness improvement
+
+---
 
 ## v1.30.0 Focus Mode Handling for Custom Perspectives (Issue #68)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -143,28 +143,30 @@ export function createValidationError(message: string, details?: string): Struct
  * Categorize raw errors from script execution into structured errors
  * Used by scriptExecution.ts to provide consistent error handling
  */
-export function categorizeError(error: any): StructuredError {
-  const message = error.message?.toLowerCase() || '';
-  const stderr = error.stderr?.toLowerCase() || '';
+export function categorizeError(error: unknown): StructuredError {
+  // Safely extract message using type guards
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  const message = errorMessage.toLowerCase();
+  const stderr = (isExecException(error) ? error.stderr : '')?.toLowerCase() || '';
   const combined = message + ' ' + stderr;
 
   // Timeout errors (from our EXEC_OPTIONS timeout)
-  if (error.killed && error.signal === 'SIGTERM') {
-    return createTimeoutError(error.message);
+  if (isExecException(error) && error.killed && error.signal === 'SIGTERM') {
+    return createTimeoutError(errorMessage);
   }
 
   // Permission errors
   if (combined.includes('not authorized') ||
       combined.includes('-1743') ||
       combined.includes('permission')) {
-    return createPermissionError(error.message);
+    return createPermissionError(errorMessage);
   }
 
   // App not running
   if (combined.includes('not running') ||
       combined.includes('-600') ||
       combined.includes("application isn't running")) {
-    return createAppUnavailableError(error.message);
+    return createAppUnavailableError(errorMessage);
   }
 
   // Script syntax errors
@@ -175,33 +177,46 @@ export function categorizeError(error: any): StructuredError {
         code: ErrorCodes.SCRIPT_SYNTAX_ERROR,
         type: 'script_error',
         message: 'Script syntax error',
-        details: error.message,
+        details: errorMessage,
         retryable: false
       }
     };
   }
 
   // Unknown errors
+  const errorStack = error instanceof Error ? error.stack : undefined;
   return {
     success: false,
     error: {
       code: ErrorCodes.UNKNOWN_ERROR,
       type: 'unknown',
-      message: error.message || 'Unknown error occurred',
-      details: error.stack,
+      message: errorMessage || 'Unknown error occurred',
+      details: errorStack,
       retryable: false
     }
   };
 }
 
 /**
+ * Type guard for Node.js ExecException with process termination properties.
+ * Used to safely access error.killed, error.signal, and error.stderr.
+ */
+export function isExecException(error: unknown): error is NodeJS.ErrnoException & {
+  killed?: boolean;
+  signal?: NodeJS.Signals;
+  stderr?: string;
+} {
+  return typeof error === 'object' && error !== null && 'killed' in error;
+}
+
+/**
  * Check if an error is a StructuredError
  */
-export function isStructuredError(error: any): error is StructuredError {
-  return error &&
-         typeof error === 'object' &&
-         error.success === false &&
-         error.error &&
-         typeof error.error.code === 'string' &&
-         typeof error.error.type === 'string';
+export function isStructuredError(error: unknown): error is StructuredError {
+  if (typeof error !== 'object' || error === null) return false;
+  const obj = error as Record<string, unknown>;
+  if (obj.success !== false) return false;
+  if (typeof obj.error !== 'object' || obj.error === null) return false;
+  const errObj = obj.error as Record<string, unknown>;
+  return typeof errObj.code === 'string' && typeof errObj.type === 'string';
 }

--- a/src/utils/scriptExecution.ts
+++ b/src/utils/scriptExecution.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { existsSync } from 'fs';
-import { categorizeError, StructuredError, isStructuredError } from './errors.js';
+import { categorizeError, StructuredError, isStructuredError, isExecException } from './errors.js';
 import { logger } from './logger.js';
 
 const execAsync = promisify(exec);
@@ -57,12 +57,13 @@ export async function executeJXA(script: string): Promise<any[]> {
       const preview = stdout.substring(0, 500);
       throw new Error(`Failed to parse JXA script output as JSON. Output preview: ${preview}`);
     }
-  } catch (error: any) {
+  } catch (error) {
     // Check for timeout (subprocess killed after timeout)
-    if (error.killed && error.signal === 'SIGTERM') {
+    if (isExecException(error) && error.killed && error.signal === 'SIGTERM') {
       throw new Error('Script execution timed out after 30 seconds. OmniFocus may be unresponsive.');
     }
-    log.error('Failed to execute JXA script', { error: error.message });
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    log.error('Failed to execute JXA script', { error: errorMessage });
     throw error;
   } finally {
     // Always clean up the temporary file
@@ -214,7 +215,7 @@ export async function executeOmniFocusScript(
         log.warn('Failed to cleanup temp file', { tempFile, error: (cleanupError as Error).message });
       }
     }
-  } catch (error: any) {
+  } catch (error) {
     // If it's already a structured error, use it directly
     const structuredError = isStructuredError(error) ? error : categorizeError(error);
 


### PR DESCRIPTION
## Summary

- Replace `catch (error: any)` patterns with type-safe `catch (error)` using proper type guards
- Add `isExecException` type guard for Node.js `ExecException` properties (`killed`, `signal`, `stderr`)
- Update `categorizeError` to accept `unknown` instead of `any`
- Update catch blocks in `scriptExecution.ts` to use type guards

Closes #86

## Test plan

- [x] Build passes (`npm run build`)
- [ ] Verify server starts successfully
- [ ] Test a command that succeeds (e.g., `list_projects`)
- [ ] Error paths maintain equivalent behavior (type-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)