### PR TITLE
fix: Remove duplicate variable declarations in getCustomPerspectiveTasks (Issue #95)

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,15 @@
-# OmniFocus MCP Server - What's New (v1.30.1)
+# OmniFocus MCP Server - What's New (v1.30.2)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.30.2 Fix get_custom_perspective_tasks SyntaxError (Issue #95)
+
+**Fixed `get_custom_perspective_tasks` failing with duplicate variable declaration error:**
+- The script declared `perspectiveName` and `perspectiveId` variables that conflicted with runtime injection
+- Removed duplicate declarations - these variables are now correctly provided by `scriptExecution.ts`
+- Added documentation comment explaining the runtime injection pattern
+
+---
 
 ## v1.30.1 Type-Safe Error Handling (Issue #86)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/utils/omnifocusScripts/getCustomPerspectiveTasks.js
+++ b/src/utils/omnifocusScripts/getCustomPerspectiveTasks.js
@@ -2,9 +2,9 @@
 // Based on improved user-provided code
 
 (() => {
-  // Declare variables needed for cleanup outside try block
-  let perspectiveName = null;
-  let perspectiveId = null;
+  // Runtime injection: injectedArgs, perspectiveName, perspectiveId, and other
+  // parameters are injected by executeOmniFocusScript() before this code runs.
+  // See scriptExecution.ts for the full list of injected variables.
   let originalFocus = null;
   let focusWasActive = false;
   let focusCleared = false;
@@ -12,10 +12,6 @@
   let focusTarget = null;
 
   try {
-    // Get injected parameters
-    perspectiveName = injectedArgs && injectedArgs.perspectiveName ? injectedArgs.perspectiveName : null;
-    perspectiveId = injectedArgs && injectedArgs.perspectiveId ? injectedArgs.perspectiveId : null;
-
     // Get Focus state BEFORE any operations
     originalFocus = document.focus;
     focusWasActive = originalFocus !== null;


### PR DESCRIPTION
## Summary
- Fixes #95: `get_custom_perspective_tasks` fails with `SyntaxError: Cannot declare a let variable twice: 'perspectiveName'`
- Removes duplicate variable declarations that conflicted with the injection system in `scriptExecution.ts`
- Bumps version to 1.30.2

## Root Cause
The script declared `perspectiveName` and `perspectiveId` as `let` variables, but `scriptExecution.ts` already injects these as `const` declarations. When the script was assembled at runtime, both declarations ended up in the same scope, causing a JavaScript SyntaxError.

## Changes
- Remove duplicate `let perspectiveName = null;` and `let perspectiveId = null;` declarations
- Remove redundant re-assignment from `injectedArgs` (the injection already handles this)
- Add comments documenting that these variables are injected by `scriptExecution.ts`

## Test plan
- [ ] Verify `get_custom_perspective_tasks({ perspectiveName: "Dashboard" })` works without SyntaxError
- [ ] Verify `get_custom_perspective_tasks({ perspectiveName: "Dashboard", ignoreFocus: true })` works
- [ ] Verify `get_custom_perspective_tasks({ perspectiveName: "Dashboard", ignoreFocus: false })` respects Focus mode
- [ ] Verify Focus mode is properly restored after query completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)