### PR TITLE
fix: Handle undefined from document.focus when no Focus mode active (Issue #97)

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,15 @@
-# OmniFocus MCP Server - What's New (v1.30.2)
+# OmniFocus MCP Server - What's New (v1.30.3)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.30.3 Fix get_custom_perspective_tasks TypeError (Issue #97)
+
+**Fixed `get_custom_perspective_tasks` crashing when no Focus mode is active:**
+- `document.focus` returns `undefined` (not `null`) when no Focus is set in OmniFocus
+- The strict equality check (`!== null`) didn't catch `undefined`, causing a TypeError on property access
+- Changed to loose equality (`!= null`) which correctly handles both `null` and `undefined`
+
+---
 
 ## v1.30.2 Fix get_custom_perspective_tasks SyntaxError (Issue #95)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.30.2",
+  "version": "1.30.3",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/utils/omnifocusScripts/getCustomPerspectiveTasks.js
+++ b/src/utils/omnifocusScripts/getCustomPerspectiveTasks.js
@@ -14,7 +14,7 @@
   try {
     // Get Focus state BEFORE any operations
     originalFocus = document.focus;
-    focusWasActive = originalFocus !== null;
+    focusWasActive = originalFocus != null;
     focusTarget = focusWasActive ? {
       name: originalFocus.name || '[unnamed]',
       type: originalFocus instanceof Project ? "project" :


### PR DESCRIPTION
## Summary
- `document.focus` returns `undefined` (not `null`) when no Focus mode is set in OmniFocus
- The strict equality check (`!== null`) didn't catch `undefined`, causing `get_custom_perspective_tasks` to crash with `TypeError: undefined is not an object (evaluating 'originalFocus.name')`
- Changed to loose equality (`!= null`) which correctly handles both `null` and `undefined`

## Test plan
- [ ] `get_custom_perspective_tasks({ perspectiveName: "<name>" })` succeeds with no Focus mode active
- [ ] `get_custom_perspective_tasks({ perspectiveName: "<name>", ignoreFocus: true })` succeeds with no Focus active
- [ ] `get_custom_perspective_tasks({ perspectiveName: "<name>", ignoreFocus: false })` succeeds with no Focus active
- [ ] With Focus active: `ignoreFocus: true` clears and restores Focus correctly
- [ ] With Focus active: `ignoreFocus: false` respects active Focus

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)