### PR TITLE
fix: Implement missing date filters and fix null-check bug

### DIFF
--- a/src/utils/omnifocusScripts/filterTasks.js
+++ b/src/utils/omnifocusScripts/filterTasks.js
@@ -252,6 +252,12 @@
           if (filters.completedYesterday && !isYesterday(task.completionDate)) {
             return false;
           }
+          if (filters.completedThisWeek && !isThisWeek(task.completionDate)) {
+            return false;
+          }
+          if (filters.completedThisMonth && !isThisMonth(task.completionDate)) {
+            return false;
+          }
           if (filters.completedBefore) {
             if (!task.completionDate) return false;
             if (new Date(task.completionDate) >= new Date(filters.completedBefore)) return false;


### PR DESCRIPTION
The filter_tasks tool schema defined 11 date filters that were not implemented. Tasks with null dates were incorrectly included when using range filters due to JavaScript short-circuit evaluation.

Add due date filters: dueToday, dueThisWeek, dueThisMonth, dueBefore, dueAfter, overdue. Add defer date filters: deferToday, deferThisWeek, deferBefore, deferAfter, deferAvailable.

Fix null-check bug in plannedBefore, plannedAfter, completedBefore, and completedAfter filters by using early returns with explicit null checks instead of short-circuit evaluation.