### PR TITLE
fix: Bring batch_filter_tasks to date filter parity with filter_tasks

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,20 @@
-# OmniFocus MCP Server - What's New (v1.30.5)
+# OmniFocus MCP Server - What's New (v1.30.6)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.30.6 Bring batch_filter_tasks to date filter parity (Issue #103)
+
+**`batch_filter_tasks` now supports the same date filters as `filter_tasks`:**
+- Added 16 date filter parameters across due, defer, planned, and completion date categories
+- Added `isThisMonth()` helper for month-based comparisons
+- Added `wantsCompletedTasks` logic so completion date filters correctly include completed tasks
+- All range filters (`*Before`, `*After`) use the early-return null-check pattern from v1.30.5
+- Added `plannedDate` and `completedDate` to task output and sort options
+- Updated Zod schema and TypeScript interface for full type safety
+
+**Intentionally excluded** from batch (project-scoped by design): `searchText`, tag filters, estimate filters, `inInbox`, `countOnly`, `perspective`.
+
+---
 
 ## v1.30.5 Implement missing date filters and fix null-check bug (PR #101)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.30.5",
+  "version": "1.30.6",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/tools/definitions/batchFilterTasks.ts
+++ b/src/tools/definitions/batchFilterTasks.ts
@@ -25,14 +25,37 @@ export const schema = z.object({
   // Due date filtering
   dueToday: z.boolean().optional().describe("Show tasks due today"),
   dueThisWeek: z.boolean().optional().describe("Show tasks due this week"),
+  dueThisMonth: z.boolean().optional().describe("Show tasks due this month"),
+  dueBefore: z.string().optional().describe("Show tasks due before this date (ISO format: YYYY-MM-DD)"),
+  dueAfter: z.string().optional().describe("Show tasks due after this date (ISO format: YYYY-MM-DD)"),
   overdue: z.boolean().optional().describe("Show overdue tasks only"),
+
+  // Defer date filtering
+  deferToday: z.boolean().optional().describe("Show tasks deferred to today"),
+  deferThisWeek: z.boolean().optional().describe("Show tasks deferred to this week"),
+  deferBefore: z.string().optional().describe("Show tasks with defer date before this date (ISO format: YYYY-MM-DD)"),
+  deferAfter: z.string().optional().describe("Show tasks with defer date after this date (ISO format: YYYY-MM-DD)"),
+  deferAvailable: z.boolean().optional().describe("Show tasks whose defer date has passed (now available)"),
+
+  // Planned date filtering
+  plannedToday: z.boolean().optional().describe("Show tasks planned for today"),
+  plannedThisWeek: z.boolean().optional().describe("Show tasks planned for this week"),
+  plannedBefore: z.string().optional().describe("Show tasks with planned date before this date (ISO format: YYYY-MM-DD)"),
+  plannedAfter: z.string().optional().describe("Show tasks with planned date after this date (ISO format: YYYY-MM-DD)"),
+
+  // Completion date filtering
+  completedToday: z.boolean().optional().describe("Show tasks completed today"),
+  completedThisWeek: z.boolean().optional().describe("Show tasks completed this week"),
+  completedThisMonth: z.boolean().optional().describe("Show tasks completed this month"),
+  completedBefore: z.string().optional().describe("Show tasks completed before this date (ISO format: YYYY-MM-DD)"),
+  completedAfter: z.string().optional().describe("Show tasks completed after this date (ISO format: YYYY-MM-DD)"),
 
   // Other filters
   flagged: z.boolean().optional().describe("Filter by flagged status"),
 
   // Output control
   limit: z.number().max(500).optional().describe("Maximum tasks per project (default: 100)"),
-  sortBy: z.enum(["name", "dueDate", "deferDate", "flagged"]).optional().describe("Sort results by field"),
+  sortBy: z.enum(["name", "dueDate", "deferDate", "plannedDate", "completedDate", "flagged"]).optional().describe("Sort results by field"),
   sortOrder: z.enum(["asc", "desc"]).optional().describe("Sort order (default: asc)")
 });
 

--- a/src/tools/primitives/batchFilterTasks.ts
+++ b/src/tools/primitives/batchFilterTasks.ts
@@ -15,7 +15,30 @@ export interface BatchFilterTasksOptions {
   // Due date filters
   dueToday?: boolean;
   dueThisWeek?: boolean;
+  dueThisMonth?: boolean;
+  dueBefore?: string;
+  dueAfter?: string;
   overdue?: boolean;
+
+  // Defer date filters
+  deferToday?: boolean;
+  deferThisWeek?: boolean;
+  deferBefore?: string;
+  deferAfter?: string;
+  deferAvailable?: boolean;
+
+  // Planned date filters
+  plannedToday?: boolean;
+  plannedThisWeek?: boolean;
+  plannedBefore?: string;
+  plannedAfter?: string;
+
+  // Completion date filters
+  completedToday?: boolean;
+  completedThisWeek?: boolean;
+  completedThisMonth?: boolean;
+  completedBefore?: string;
+  completedAfter?: string;
 
   // Other filters
   flagged?: boolean;
@@ -82,8 +105,28 @@ function formatBatchResults(data: any, options: BatchFilterTasksOptions): string
     filterParts.push(`Flagged: ${options.flagged ? 'Yes' : 'No'}`);
   }
   if (options.dueToday) filterParts.push('Due: Today');
-  if (options.dueThisWeek) filterParts.push('Due: This Week');
-  if (options.overdue) filterParts.push('Overdue only');
+  else if (options.dueThisWeek) filterParts.push('Due: This Week');
+  else if (options.dueThisMonth) filterParts.push('Due: This Month');
+  else if (options.overdue) filterParts.push('Due: Overdue');
+  if (options.dueBefore) filterParts.push(`Due before: ${options.dueBefore}`);
+  if (options.dueAfter) filterParts.push(`Due after: ${options.dueAfter}`);
+
+  if (options.deferAvailable) filterParts.push('Defer: Available');
+  else if (options.deferToday) filterParts.push('Defer: Today');
+  else if (options.deferThisWeek) filterParts.push('Defer: This Week');
+  if (options.deferBefore) filterParts.push(`Defer before: ${options.deferBefore}`);
+  if (options.deferAfter) filterParts.push(`Defer after: ${options.deferAfter}`);
+
+  if (options.plannedToday) filterParts.push('Planned: Today');
+  else if (options.plannedThisWeek) filterParts.push('Planned: This Week');
+  if (options.plannedBefore) filterParts.push(`Planned before: ${options.plannedBefore}`);
+  if (options.plannedAfter) filterParts.push(`Planned after: ${options.plannedAfter}`);
+
+  if (options.completedToday) filterParts.push('Completed: Today');
+  else if (options.completedThisWeek) filterParts.push('Completed: This Week');
+  else if (options.completedThisMonth) filterParts.push('Completed: This Month');
+  if (options.completedBefore) filterParts.push(`Completed before: ${options.completedBefore}`);
+  if (options.completedAfter) filterParts.push(`Completed after: ${options.completedAfter}`);
 
   if (filterParts.length > 0) {
     output += `**Common Filters**: ${filterParts.join(' | ')}\n\n`;
@@ -163,6 +206,16 @@ function formatTask(task: any): string {
   const deferDateStr = formatDateSafe(task.deferDate);
   if (deferDateStr) {
     output += `  🚀 Defer: ${deferDateStr}\n`;
+  }
+
+  const plannedDateStr = formatDateSafe(task.plannedDate);
+  if (plannedDateStr) {
+    output += `  📋 Planned: ${plannedDateStr}\n`;
+  }
+
+  const completedDateStr = formatDateSafe(task.completedDate);
+  if (completedDateStr) {
+    output += `  ✅ Done: ${completedDateStr}\n`;
   }
 
   // Tags

--- a/src/utils/omnifocusScripts/batchFilterTasks.js
+++ b/src/utils/omnifocusScripts/batchFilterTasks.js
@@ -7,12 +7,41 @@
     const projectNames = args.projectNames || [];
     const taskStatus = args.taskStatus || null;
     const flagged = args.flagged !== undefined ? args.flagged : null;
+    // Due date filters
     const dueToday = args.dueToday || false;
     const dueThisWeek = args.dueThisWeek || false;
+    const dueThisMonth = args.dueThisMonth || false;
+    const dueBefore = args.dueBefore || null;
+    const dueAfter = args.dueAfter || null;
     const overdue = args.overdue || false;
+
+    // Defer date filters
+    const deferToday = args.deferToday || false;
+    const deferThisWeek = args.deferThisWeek || false;
+    const deferBefore = args.deferBefore || null;
+    const deferAfter = args.deferAfter || null;
+    const deferAvailable = args.deferAvailable || false;
+
+    // Planned date filters
+    const plannedToday = args.plannedToday || false;
+    const plannedThisWeek = args.plannedThisWeek || false;
+    const plannedBefore = args.plannedBefore || null;
+    const plannedAfter = args.plannedAfter || null;
+
+    // Completion date filters
+    const completedToday = args.completedToday || false;
+    const completedThisWeek = args.completedThisWeek || false;
+    const completedThisMonth = args.completedThisMonth || false;
+    const completedBefore = args.completedBefore || null;
+    const completedAfter = args.completedAfter || null;
+
     const limit = args.limit || 100;
     const sortBy = args.sortBy || "name";
     const sortOrder = args.sortOrder || "asc";
+
+    // Determine if we need completed tasks
+    const wantsCompletedTasks = completedToday || completedThisWeek ||
+                                completedThisMonth || completedBefore || completedAfter;
 
     // formatDate and taskStatusMap are provided by sharedUtils.js
 
@@ -46,6 +75,14 @@
       if (!date) return false;
       const now = new Date();
       return new Date(date) < now;
+    }
+
+    function isThisMonth(date) {
+      if (!date) return false;
+      const now = new Date();
+      const checkDate = new Date(date);
+      return checkDate.getMonth() === now.getMonth() &&
+             checkDate.getFullYear() === now.getFullYear();
     }
 
     // Build project lookup maps (only actual projects, not action groups)
@@ -129,10 +166,17 @@
           try {
             const status = getTaskStatus(task.taskStatus);
 
-            // Exclude completed/dropped unless explicitly requested
-            if (status === "Completed" || status === "Dropped") {
-              if (!taskStatus || !taskStatus.includes(status)) {
+            // Completed tasks logic
+            if (wantsCompletedTasks) {
+              if (status !== "Completed") {
                 return false;
+              }
+            } else {
+              // Exclude completed/dropped unless explicitly requested via taskStatus
+              if (status === "Completed" || status === "Dropped") {
+                if (!taskStatus || !taskStatus.includes(status)) {
+                  return false;
+                }
               }
             }
 
@@ -148,6 +192,43 @@
               return false;
             }
 
+            // Completion date filters
+            if (wantsCompletedTasks) {
+              if (completedToday && !isToday(task.completionDate)) {
+                return false;
+              }
+              if (completedThisWeek && !isThisWeek(task.completionDate)) {
+                return false;
+              }
+              if (completedThisMonth && !isThisMonth(task.completionDate)) {
+                return false;
+              }
+              if (completedBefore) {
+                if (!task.completionDate) return false;
+                if (new Date(task.completionDate) >= new Date(completedBefore)) return false;
+              }
+              if (completedAfter) {
+                if (!task.completionDate) return false;
+                if (new Date(task.completionDate) <= new Date(completedAfter)) return false;
+              }
+            }
+
+            // Planned date filters
+            if (plannedToday && !isToday(task.plannedDate)) {
+              return false;
+            }
+            if (plannedThisWeek && !isThisWeek(task.plannedDate)) {
+              return false;
+            }
+            if (plannedBefore) {
+              if (!task.plannedDate) return false;
+              if (new Date(task.plannedDate) >= new Date(plannedBefore)) return false;
+            }
+            if (plannedAfter) {
+              if (!task.plannedDate) return false;
+              if (new Date(task.plannedDate) <= new Date(plannedAfter)) return false;
+            }
+
             // Due date filters
             if (dueToday && !isToday(task.dueDate)) {
               return false;
@@ -155,8 +236,39 @@
             if (dueThisWeek && !isThisWeek(task.dueDate)) {
               return false;
             }
+            if (dueThisMonth && !isThisMonth(task.dueDate)) {
+              return false;
+            }
             if (overdue && !isOverdue(task.dueDate)) {
               return false;
+            }
+            if (dueBefore) {
+              if (!task.dueDate) return false;
+              if (new Date(task.dueDate) >= new Date(dueBefore)) return false;
+            }
+            if (dueAfter) {
+              if (!task.dueDate) return false;
+              if (new Date(task.dueDate) <= new Date(dueAfter)) return false;
+            }
+
+            // Defer date filters
+            if (deferToday && !isToday(task.deferDate)) {
+              return false;
+            }
+            if (deferThisWeek && !isThisWeek(task.deferDate)) {
+              return false;
+            }
+            if (deferBefore) {
+              if (!task.deferDate) return false;
+              if (new Date(task.deferDate) >= new Date(deferBefore)) return false;
+            }
+            if (deferAfter) {
+              if (!task.deferDate) return false;
+              if (new Date(task.deferDate) <= new Date(deferAfter)) return false;
+            }
+            if (deferAvailable) {
+              if (!task.deferDate) return false;
+              if (new Date(task.deferDate) > new Date()) return false;
             }
 
             return true;
@@ -179,6 +291,18 @@
         tasks.sort((a, b) => {
           const dateA = a.deferDate || new Date('2099-12-31');
           const dateB = b.deferDate || new Date('2099-12-31');
+          return sortOrder === "desc" ? dateB - dateA : dateA - dateB;
+        });
+      } else if (sortBy === "plannedDate") {
+        tasks.sort((a, b) => {
+          const dateA = a.plannedDate || new Date('2099-12-31');
+          const dateB = b.plannedDate || new Date('2099-12-31');
+          return sortOrder === "desc" ? dateB - dateA : dateA - dateB;
+        });
+      } else if (sortBy === "completedDate") {
+        tasks.sort((a, b) => {
+          const dateA = a.completionDate || new Date('1900-01-01');
+          const dateB = b.completionDate || new Date('1900-01-01');
           return sortOrder === "desc" ? dateB - dateA : dateA - dateB;
         });
       } else if (sortBy === "flagged") {
@@ -218,6 +342,8 @@
             flagged: task.flagged,
             dueDate: formatDate(task.dueDate),
             deferDate: formatDate(task.deferDate),
+            plannedDate: formatDate(task.plannedDate),
+            completedDate: formatDate(task.completionDate),
             estimatedMinutes: task.estimatedMinutes,
             createdDate: formatDate(task.added),
             tags: task.tags.map(tag => ({


### PR DESCRIPTION
## Summary
- Add 16 date filter parameters to `batch_filter_tasks` (due, defer, planned, completion categories)
- Add `isThisMonth()` helper and `wantsCompletedTasks` logic
- All range filters use early-return null-check pattern from v1.30.5
- Add `plannedDate` and `completedDate` to task output and sort options
- Update Zod schema, TypeScript interface, and OmniJS script in sync
- Bump version to `1.30.6`

## Context
`batch_filter_tasks` only supported 3 date filters (`dueToday`, `dueThisWeek`, `overdue`) while `filter_tasks` supported 20+ after PR #101. This brings parity for all date filters.

**Intentionally excluded** (batch is project-scoped by design): `searchText`, tag filters, estimate filters, `inInbox`, `countOnly`, `perspective`.

## Test plan
- [ ] `npm run build` passes
- [ ] Verify filter logic matches `filterTasks.js` patterns
- [ ] Spot-check new filters with OmniFocus

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)