### PR TITLE
fix: Surface silent catch block errors in filter operations (#104)

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,20 @@
-# OmniFocus MCP Server - What's New (v1.30.6)
+# OmniFocus MCP Server - What's New (v1.30.7)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.30.7 Surface silent catch block errors in filter operations (Issue #104)
+
+**Improved error visibility in `filter_tasks` and `batch_filter_tasks`:**
+- Per-task filter errors are now counted and reported instead of silently excluding tasks
+- Task serialization errors are now counted and reported instead of silently dropping tasks
+- Project-level errors in batch operations now produce a result entry with error details instead of silently skipping the project
+- Warning section displayed in output when any tasks were excluded due to processing errors
+- Up to 3 sample error messages captured for troubleshooting
+- Server-side `log.warn` emitted when processing errors are present
+
+**Impact:** Error-free operations produce identical output to before. Warnings only appear when errors actually occur.
+
+---
 
 ## v1.30.6 Bring batch_filter_tasks to date filter parity (Issue #103)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.30.6",
+  "version": "1.30.7",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/tools/primitives/batchFilterTasks.ts
+++ b/src/tools/primitives/batchFilterTasks.ts
@@ -81,6 +81,10 @@ export async function batchFilterTasks(options: BatchFilterTasksOptions = {}): P
         throw new Error(data.error);
       }
 
+      if (data.processingErrors) {
+        log.warn('Batch filter returned processing errors', data.processingErrors);
+      }
+
       return formatBatchResults(data, options);
     }
 
@@ -136,6 +140,29 @@ function formatBatchResults(data: any, options: BatchFilterTasksOptions): string
   const projectCount = data.projectResults?.length || 0;
   const totalTasks = data.projectResults?.reduce((sum: number, p: any) => sum + (p.taskCount || 0), 0) || 0;
   output += `**Summary**: ${totalTasks} tasks across ${projectCount} projects\n\n`;
+
+  // Display processing error warnings if any tasks were silently excluded
+  if (data.processingErrors) {
+    const pe = data.processingErrors;
+    const totalErrors = (pe.filterErrors || 0) + (pe.serializationErrors || 0) + (pe.projectErrors || 0);
+    if (totalErrors > 0) {
+      output += `⚠️ **Processing Warnings**:\n`;
+      if (pe.filterErrors > 0) {
+        output += `- ${pe.filterErrors} task${pe.filterErrors === 1 ? '' : 's'} excluded due to filter evaluation errors\n`;
+      }
+      if (pe.serializationErrors > 0) {
+        output += `- ${pe.serializationErrors} task${pe.serializationErrors === 1 ? '' : 's'} dropped due to serialization errors\n`;
+      }
+      if (pe.projectErrors > 0) {
+        output += `- ${pe.projectErrors} project${pe.projectErrors === 1 ? '' : 's'} failed to load\n`;
+      }
+      if (pe.samples && pe.samples.length > 0) {
+        output += `- Samples: ${pe.samples.join('; ')}\n`;
+      }
+      output += '\n';
+    }
+  }
+
   output += `---\n\n`;
 
   // Results by project
@@ -152,7 +179,9 @@ function formatBatchResults(data: any, options: BatchFilterTasksOptions): string
       }
       output += `\n\n`;
 
-      if (tasks.length === 0) {
+      if (projectResult.error) {
+        output += `⚠️ _Error: ${projectResult.error}_\n\n`;
+      } else if (tasks.length === 0) {
         output += `_No matching tasks_\n\n`;
       } else {
         for (const task of tasks) {

--- a/src/tools/primitives/filterTasks.ts
+++ b/src/tools/primitives/filterTasks.ts
@@ -115,6 +115,10 @@ export async function filterTasks(options: FilterTasksOptions = {}): Promise<str
         throw new Error(data.error);
       }
 
+      if (data.processingErrors) {
+        log.warn('Filter returned processing errors', data.processingErrors);
+      }
+
       // Handle countOnly mode - return simplified output
       if (data.countOnly) {
         const filterSummary = buildFilterSummary(options);
@@ -179,6 +183,25 @@ export async function filterTasks(options: FilterTasksOptions = {}): Promise<str
         }
       } else {
         output += "No task data available\n";
+      }
+
+      // Display processing error warnings if any tasks were silently excluded
+      if (data.processingErrors) {
+        const pe = data.processingErrors;
+        const totalErrors = (pe.filterErrors || 0) + (pe.serializationErrors || 0);
+        if (totalErrors > 0) {
+          output += `\n⚠️ **Processing Warnings**:\n`;
+          if (pe.filterErrors > 0) {
+            output += `- ${pe.filterErrors} task${pe.filterErrors === 1 ? '' : 's'} excluded due to filter evaluation errors\n`;
+          }
+          if (pe.serializationErrors > 0) {
+            output += `- ${pe.serializationErrors} task${pe.serializationErrors === 1 ? '' : 's'} dropped due to serialization errors\n`;
+          }
+          if (pe.samples && pe.samples.length > 0) {
+            output += `- Samples: ${pe.samples.join('; ')}\n`;
+          }
+          output += '\n';
+        }
       }
 
       return output;

--- a/src/utils/omnifocusScripts/batchFilterTasks.js
+++ b/src/utils/omnifocusScripts/batchFilterTasks.js
@@ -3,6 +3,13 @@
   try {
     const args = typeof injectedArgs !== 'undefined' ? injectedArgs : {};
 
+    // Error tracking - count errors instead of silently swallowing them
+    let filterErrorCount = 0;
+    let serializationErrorCount = 0;
+    let projectErrorCount = 0;
+    const errorSamples = [];
+    const MAX_ERROR_SAMPLES = 3;
+
     const projectIds = args.projectIds || [];
     const projectNames = args.projectNames || [];
     const taskStatus = args.taskStatus || null;
@@ -273,11 +280,26 @@
 
             return true;
           } catch (e) {
+            filterErrorCount++;
+            if (errorSamples.length < MAX_ERROR_SAMPLES) {
+              errorSamples.push('Filter in "' + project.name + '": ' + e);
+            }
             return false;
           }
         });
       } catch (e) {
-        // Skip project if error accessing tasks
+        projectErrorCount++;
+        if (errorSamples.length < MAX_ERROR_SAMPLES) {
+          errorSamples.push('Project "' + project.name + '": ' + e);
+        }
+        projectResults.push({
+          projectId: project.id.primaryKey,
+          projectName: project.name,
+          error: 'Failed to access tasks: ' + e,
+          taskCount: 0,
+          totalCount: 0,
+          tasks: []
+        });
       }
 
       // Sort tasks
@@ -352,6 +374,10 @@
             }))
           };
         } catch (e) {
+          serializationErrorCount++;
+          if (errorSamples.length < MAX_ERROR_SAMPLES) {
+            errorSamples.push('Serialize in "' + project.name + '": ' + e);
+          }
           return null;
         }
       }).filter(t => t !== null);
@@ -365,13 +391,24 @@
       });
     }
 
-    return JSON.stringify({
+    const response = {
       success: true,
       projectResults: projectResults,
       notFound: notFound,
       totalProjects: projectResults.length,
       totalTasks: projectResults.reduce((sum, p) => sum + p.taskCount, 0)
-    });
+    };
+
+    if (filterErrorCount > 0 || serializationErrorCount > 0 || projectErrorCount > 0) {
+      response.processingErrors = {
+        filterErrors: filterErrorCount,
+        serializationErrors: serializationErrorCount,
+        projectErrors: projectErrorCount,
+        samples: errorSamples
+      };
+    }
+
+    return JSON.stringify(response);
 
   } catch (error) {
     return JSON.stringify({

--- a/src/utils/omnifocusScripts/filterTasks.js
+++ b/src/utils/omnifocusScripts/filterTasks.js
@@ -4,6 +4,12 @@
     // Get parameters
     const args = typeof injectedArgs !== 'undefined' ? injectedArgs : {};
 
+    // Error tracking - count errors instead of silently swallowing them
+    let filterErrorCount = 0;
+    let serializationErrorCount = 0;
+    const errorSamples = [];
+    const MAX_ERROR_SAMPLES = 3;
+
     const filters = {
       taskStatus: args.taskStatus || null,
       perspective: args.perspective || "all",
@@ -333,6 +339,10 @@
 
         return true;
       } catch (error) {
+        filterErrorCount++;
+        if (errorSamples.length < MAX_ERROR_SAMPLES) {
+          errorSamples.push('Filter: ' + error);
+        }
         return false;
       }
     });
@@ -431,9 +441,20 @@
 
         exportData.tasks.push(taskData);
       } catch (taskError) {
-        // Skip tasks with processing errors
+        serializationErrorCount++;
+        if (errorSamples.length < MAX_ERROR_SAMPLES) {
+          errorSamples.push('Serialize "' + task.name + '": ' + taskError);
+        }
       }
     });
+
+    if (filterErrorCount > 0 || serializationErrorCount > 0) {
+      exportData.processingErrors = {
+        filterErrors: filterErrorCount,
+        serializationErrors: serializationErrorCount,
+        samples: errorSamples
+      };
+    }
 
     return JSON.stringify(exportData);
 


### PR DESCRIPTION
## Summary

- Replace silent error swallowing with error counting and reporting in `filterTasks.js` and `batchFilterTasks.js`
- Catch blocks now track `filterErrorCount`, `serializationErrorCount`, and `projectErrorCount` with up to 3 sample error messages
- `processingErrors` field added to JSON response only when errors occur
- TypeScript formatting layer displays warning section and emits `log.warn` when processing errors are present
- The empty project-level catch in `batchFilterTasks.js` (worst offender) now pushes an error result entry instead of silently skipping

Fixes #104

**Note:** Items #3 and #4 from the issue (outer catch returns success-shaped error / TypeScript should set `isError`) were investigated and found to already work correctly — `executeOmniFocusScript` parses JSON into an object, which hits the `data.error` check and throws through to the definitions layer where `isError: true` is set.

## Test plan

- [ ] `npm run build` compiles cleanly
- [ ] `filter_tasks` with normal filters produces identical output (no warnings)
- [ ] `batch_filter_tasks` with valid projects produces identical output (no warnings)
- [ ] Verify `processingErrors` field only appears in JSON when errors occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)