### PR TITLE
fix: Include processingErrors in countOnly mode for filter_tasks (#109)

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,15 @@
-# OmniFocus MCP Server - What's New (v1.30.7)
+# OmniFocus MCP Server - What's New (v1.30.8)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.30.8 Fix countOnly mode discarding processing errors (Issue #109)
+
+**Bug fix for `filter_tasks` with `countOnly: true`:**
+- The `countOnly` code path now includes `processingErrors` when filter evaluation errors occur
+- Count-only results display the same warning section as full results when tasks are silently excluded
+- Previously, filter errors were silently discarded in count-only mode, giving inaccurate counts with no warning
+
+---
 
 ## v1.30.7 Surface silent catch block errors in filter operations (Issue #104)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.30.7",
+  "version": "1.30.8",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/tools/primitives/filterTasks.ts
+++ b/src/tools/primitives/filterTasks.ts
@@ -127,6 +127,18 @@ export async function filterTasks(options: FilterTasksOptions = {}): Promise<str
         if (filterSummary) {
           output += `**Filter**: ${filterSummary}\n`;
         }
+        // Display processing error warnings if any tasks were silently excluded
+        if (data.processingErrors) {
+          const pe = data.processingErrors;
+          if ((pe.filterErrors || 0) > 0) {
+            output += `\n⚠️ **Processing Warnings**:\n`;
+            output += `- ${pe.filterErrors} task${pe.filterErrors === 1 ? '' : 's'} excluded due to filter evaluation errors\n`;
+            if (pe.samples && pe.samples.length > 0) {
+              output += `- Samples: ${pe.samples.join('; ')}\n`;
+            }
+            output += '\n';
+          }
+        }
         return output;
       }
 

--- a/src/utils/omnifocusScripts/filterTasks.js
+++ b/src/utils/omnifocusScripts/filterTasks.js
@@ -381,7 +381,7 @@
 
     // countOnly mode - return just the count without task data
     if (filters.countOnly) {
-      return JSON.stringify({
+      const result = {
         count: totalMatchingCount,
         countOnly: true,
         filters: {
@@ -395,7 +395,15 @@
           flagged: filters.flagged,
           inInbox: filters.inInbox
         }
-      });
+      };
+      if (filterErrorCount > 0) {
+        result.processingErrors = {
+          filterErrors: filterErrorCount,
+          serializationErrors: 0,
+          samples: errorSamples
+        };
+      }
+      return JSON.stringify(result);
     }
 
     // Limit results


### PR DESCRIPTION
The countOnly code path returned early without attaching processingErrors,
silently discarding filter evaluation errors and giving inaccurate counts.
Now includes error data in the response and displays warnings to users.

https://claude.ai/code/session_01H76DhLLqXu1YotWN6k6cwT