### PR TITLE
fix(#112): make add_project folderName lookup case-insensitive

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,14 @@
-# OmniFocus MCP Server - What's New (v1.30.7)
+# OmniFocus MCP Server - What's New (v1.30.8)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.30.8 Fix add_project folderName case sensitivity (Issue #112)
+
+**`add_project` folder name lookup is now case-insensitive.** Previously `add_project` required an exact-case match on `folderName`, while `batch_add_items` and `edit_item` already matched case-insensitively. All three tools now behave consistently — e.g. `folderName: "work projects"` resolves to an existing `Work Projects` folder.
+
+**Note on issue #112 scope.** The issue also reported two other defects: (1) `batch_add_items` with `folderName` + `sequential: true` flipping projects to Dropped; (2) `edit_item` / `batch_edit_items` with `newProjectStatus: "active"` failing to recover Dropped projects. Neither could be reproduced in diagnostic testing against v1.30.7 across multiple variants (including a sequential project with child tasks, and drop-then-recover via both `edit_item` and `batch_edit_items`). The cited source code is unchanged; applying speculative fixes without a reproducer was deliberately avoided. Those reports remain open on #112 pending fresh steps-to-reproduce.
+
+---
 
 ## v1.30.7 Surface silent catch block errors in filter operations (Issues #104, #109)
 

--- a/docs/superpowers/plans/2026-04-19-issue-112-findings.md
+++ b/docs/superpowers/plans/2026-04-19-issue-112-findings.md
@@ -1,0 +1,20 @@
+# Issue #112 — Phase 1 Diagnostic Findings
+
+**Environment:** of-mcp `v1.30.7`, branch `fix/issue-112-batch-add-sequential-dropped`, OmniFocus 4 Pro on macOS, 2026-04-19.
+
+## Answers
+
+- **Q1** (`add_project` + `folderName` + `sequential: true` at creation): `Active` / `Sequential: Yes`. Does not reproduce D1.
+- **Q2 (pre-edit diff)**: No difference in `get_project_by_id` output between `id_a` (add_project, no sequential) and `id_b` (batch_add_items, no sequential). Identical folder, status, task counts, review metadata.
+- **Q2 (post-edit)**: Both `id_a` and `id_b` show `Sequential: Yes` after `edit_item newSequential: true`. Setter applied correctly on both.
+- **Q3** (`add_project` + later `edit_item newSequential: true`): `id_a` stayed `Active`. Does not reproduce.
+- **Known post-edit batch reproducer** (`batch_add_items` no-seq + `edit_item newSequential: true`): `id_b` stayed `Active`. Does not reproduce.
+- **Headline creation-time batch reproducer** (`batch_add_items` + `folderName` + `sequential: true` at creation): `Active` / `Sequential: Yes`. Does not reproduce.
+
+## Decision tree output
+
+**No Phase 2 task selected.** D1 is not reproducible in this environment across all four tested variants. Applying `Task 5` / `Task 5b` would be speculative — the fix rationale requires empirical evidence that `project.task.sequential` is the state the UI reads, and no such evidence exists.
+
+## Next steps
+
+Proceed to Phase 3 (D2) and Phase 4 (D3), which are independent of D1 and have their own reproducers. Flag the null D1 result back to issue #112 and request fresh steps-to-reproduce before re-investigating.

--- a/docs/superpowers/plans/2026-04-19-issue-112-fix.md
+++ b/docs/superpowers/plans/2026-04-19-issue-112-fix.md
@@ -1,0 +1,804 @@
+# Issue #112 Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate three related defects around project creation and status handling: (D1) `batch_add_items` + `folderName` + `sequential=true` at creation flips projects to Dropped, and the same flip may occur when `sequential=true` is set later via `edit_item`/`batch_edit_items` on a batch-created project (Phase 1 Q3 confirms which post-creation paths are affected); (D2) `edit_item`/`batch_edit_items` with `newProjectStatus: "active"` reports success but cannot recover a Dropped project; (D3) `add_project` is case-sensitive on `folderName` while `batch_add_items` is case-insensitive.
+
+**Architecture:** Manual verification only (per project CLAUDE.md — no automated tests for OmniFocus-dependent code). The MCP server itself is the test harness: each diagnostic and verification step is a concrete JSON tool invocation against a live OmniFocus database, with expected output. Root cause for D1 is not determinable from source reading alone (the two code paths are functionally identical) — Phase 1 is an empirical diagnostic that dumps project state across both creation paths to locate the divergence, and only after that does the plan commit to a fix shape. D2 and D3 are independent and fixed in their own phases.
+
+**Tech Stack:** TypeScript (MCP primitives) + OmniJS (`.js` scripts in `src/utils/omnifocusScripts/`) + OmniFocus 4 Pro on macOS. Repo version starts at `1.30.7`.
+
+---
+
+## Defect inventory
+
+| ID | Summary | Files involved |
+|----|---------|---------------|
+| D1 | `batch_add_items` with `folderName` + `sequential=true` at creation flips a project to Dropped. The same flip may occur when `sequential=true` is set later via `edit_item newSequential: true` or `batch_edit_items newSequential: true` on a project created via either `add_project` or `batch_add_items`. Phase 1 Q3 confirms which combinations reproduce. | `src/utils/omnifocusScripts/batchAddItems.js` + possibly `editItem.js`/`batchEditItems.js` (Phase 1 Q3 confirms which) |
+| D2 | `edit_item`/`batch_edit_items` with `newProjectStatus: "active"` on a Dropped project reports `success: true`, `changedProperties: "status"`, but the project stays Dropped | `src/utils/omnifocusScripts/editItem.js:297-309`, `batchEditItems.js:334-346` |
+| D3 | `add_project` requires exact-case `folderName` match; `batch_add_items` does case-insensitive match | `src/utils/omnifocusScripts/addProject.js:55-62` |
+
+## Critical unknown that Phase 1 resolves
+
+The user's issue tables do not include: "`add_project` with `folderName` + `sequential: true` at creation." Without that cell, we cannot tell whether D1's mechanism is in the shared `newProject.sequential = true` code path (in which case the fix belongs in both `addProject.js` and `batchAddItems.js`) or is specific to batch context. Phase 1 fills this gap empirically **and** dumps full project state for both creation paths — we do not rely on source-reading alone, because source-reading shows the two creation paths are functionally identical and yet produce different outcomes.
+
+## Global conventions for this plan
+
+- All MCP tool calls in this plan are expressed as JSON arguments. Execute them via whatever MCP client the engineer uses (Claude Desktop, `mcp_cli`, etc.). **Never execute against the engineer's real production OmniFocus data without a sandbox folder first.**
+- Create a sandbox folder in OmniFocus at the top level named exactly `i112-test` and work entirely inside it. At the end of every phase, before starting the next phase, call `remove_item` on every `i112-*` project created during that phase.
+- After every OmniJS edit, run `npm run build` before retesting — the build copies `.js` files into `dist/`.
+- Commit after every fix step with message `fix(#112): <what changed>`; include `Co-Authored-By` trailer.
+- Bump `package.json` version once at the end of Phase 6 (single patch bump, e.g. `1.30.7` → `1.30.8`).
+
+---
+
+## Phase 0: Setup
+
+### Task 0: Branch and sandbox
+
+- [ ] **Step 1: Create a feature branch**
+
+```bash
+git checkout -b fix/issue-112-batch-add-sequential-dropped
+```
+
+- [ ] **Step 2: Build once to confirm clean baseline**
+
+```bash
+npm run build
+```
+
+Expected: exits 0, both `dist/utils/omnifocusScripts/batchAddItems.js` and `dist/utils/omnifocusScripts/editItem.js` exist.
+
+- [ ] **Step 3: Create OmniFocus sandbox folder via the MCP server**
+
+Call:
+
+```json
+{ "tool": "add_folder", "args": { "name": "i112-test" } }
+```
+
+This uses the repo's own `add_folder` tool rather than manual OmniFocus UI creation, so the step is repeatable across restarts. Expected response: `success: true`. If the folder already exists from a prior attempt, `add_folder` will either return an existing-folder result or an error — either way, confirm via `get_folder_by_id` or by running `list_projects` that the folder is present before continuing. All plan test projects will be created in this folder or a child of it.
+
+- [ ] **Step 4: Verify the MCP server can see it**
+
+Call `list_projects` (no args) and confirm no pre-existing `i112-*` projects exist. If any exist, abort and have the user manually clear the conflicting `i112-*` projects before proceeding. Do not bulk-delete unknown items via `remove_item` — a name collision could destroy unrelated user projects. Only use `remove_item` on projectIds returned by creation calls earlier in this plan (cleanup steps later in the plan all follow that pattern). If manual cleanup is not possible, restart Phase 0 using a different sandbox folder name (e.g. `i112-test-2`). Substitute the new folder name only in `folderName` arguments throughout the plan; project name prefixes (`i112-P1-...`, etc.) do not need to change since they will not collide with the new folder.
+
+- [ ] **Step 5: Record `WHATS_NEW.md` format so Phase 6 doesn't guess**
+
+Read the top ~30 lines of `docs/WHATS_NEW.md`:
+
+```bash
+head -n 30 docs/WHATS_NEW.md
+```
+
+Note two things and record them in your notes (or in the Phase 1 findings memo when you create it):
+- The H1 line as currently written (exact text and version number).
+- The first H2 entry's format — specifically whether it uses `## v1.30.7 Title` (bold sub-sections) or `## 1.30.7 (2026-xx-xx) / ### Fixes` style, or something else entirely.
+
+Phase 6 Task 11 Steps 1 and 2 assume a specific format (`## v<version> <title>` with bold sub-section labels, no `### Fixes` heading) and an H1 that embeds the version number. If either assumption is wrong, adapt those steps at execution time to match the actual file — do not force the file into a format it doesn't use.
+
+Also confirm `docs/WHATS_NEW.md` exists at all. If it does not, skip the entry entirely (the PR description still documents the change) and flag the discrepancy to the coordinator.
+
+---
+
+## Phase 1: Diagnose D1 — fill the matrix gap and dump state
+
+The goal of this phase is to answer two questions with data:
+
+- Q1: Does `add_project` with `folderName: "i112-test"` + `sequential: true` at creation produce a Dropped project? (Closes the matrix gap.)
+- Q2: What, if anything, is different in the reported state of a freshly-created project between `add_project` and `batch_add_items` at the moment of creation?
+- Q3: Does `add_project` (no sequential) followed by `edit_item newSequential: true` reproduce the Dropped flip? Or is the post-creation flip exclusive to projects created via `batch_add_items`? (Answered by id_a's post-edit state in Task 2 Step 5.)
+
+### Task 1: Matrix gap — `add_project` with sequential at creation
+
+**Files:** None modified.
+
+- [ ] **Step 1: Create a project via `add_project` with sequential at creation**
+
+Call:
+```json
+{
+  "tool": "add_project",
+  "args": {
+    "name": "i112-P1-addproject-seq-at-creation",
+    "folderName": "i112-test",
+    "sequential": true
+  }
+}
+```
+
+Note the returned `projectId`.
+
+- [ ] **Step 2: Inspect the created project**
+
+Call `get_project_by_id` with the `projectId` from Step 1. Record in Phase 1 findings (see Task 3):
+
+- `status` — `Active` is the correct behaviour; `Dropped` here would confirm the bug is **shared** between `add_project` and `batch_add_items`, not batch-specific.
+- `sequential` — expected `true`.
+- Any other fields that look abnormal (folder, due date, etc.).
+
+- [ ] **Step 3: Clean up**
+
+Call `remove_item` with `{ itemType: "project", id: "<projectId>" }`.
+
+### Task 2: State dump — compare `add_project` and `batch_add_items` outputs
+
+**Files:** None modified.
+
+- [ ] **Step 1: Create a project via `add_project` with folder + NO sequential**
+
+```json
+{
+  "tool": "add_project",
+  "args": {
+    "name": "i112-P2a-addproject-nosq",
+    "folderName": "i112-test"
+  }
+}
+```
+
+Record returned `projectId` as `id_a`.
+
+- [ ] **Step 2: Create an equivalent project via `batch_add_items` with folder + NO sequential**
+
+```json
+{
+  "tool": "batch_add_items",
+  "args": {
+    "items": [
+      { "type": "project", "name": "i112-P2b-batch-nosq", "folderName": "i112-test" }
+    ]
+  }
+}
+```
+
+Record returned `id` as `id_b`.
+
+- [ ] **Step 3: Dump every inspectable property of both projects**
+
+Call `get_project_by_id` with `{ "id": "<id_a>" }` **once** first. The response is your ground truth for which fields actually exist — the tool's schema is not re-derived in this plan. Then, for each of `id_a` and `id_b`, call `get_project_by_id` and record every top-level field the response actually contains.
+
+As an orientation, likely relevant fields include (but are not limited to): `status`, `sequential`, folder information (whatever the key is — `folderId` / `folderName` / `parentFolderId` — use what you observe), task counts (`taskCount` / `remainingTaskCount` / similar), `completedByChildren`, `containsSingletonActions`, `note`, `dueDate`, `deferDate`, review-related fields (`nextReviewDate` / `lastReviewDate` / `reviewInterval`). Do not attempt to hand-roll a field name that isn't in the actual response — if a field you expected is missing from the first dump, skip it silently (do not fabricate placeholders) and proceed with what the response actually contains.
+
+Diff the two records field-by-field. Any field that differs is a suspect for Task 3 findings.
+
+- [ ] **Step 4: Set `sequential: true` on each via `edit_item`**
+
+```json
+{ "tool": "edit_item", "args": { "itemType": "project", "id": "<id_a>", "newSequential": true } }
+```
+```json
+{ "tool": "edit_item", "args": { "itemType": "project", "id": "<id_b>", "newSequential": true } }
+```
+
+Both responses MUST report `success: true`. If either returns `success: false`, halt and record the failure in the findings memo before proceeding to Step 5. Otherwise, record each `changedProperties` value and continue.
+
+- [ ] **Step 5: Re-dump both projects after the edit**
+
+For each id, call `get_project_by_id` again. Record new `status` and `sequential`. Per the issue reporter's table, `id_b` (the batch_add_items path) is expected to flip to `Dropped`. The behaviour of `id_a` (the add_project path) is exactly the open question Q3 from the Phase 1 intro: record whether it stays `Active` or flips to `Dropped`, then proceed without halting. If `id_b` does NOT flip to `Dropped`, halt the plan and surface the environment discrepancy to the engineer's coordinator (or the issue reporter directly) before proceeding.
+
+- [ ] **Step 6: Clean up**
+
+`remove_item` both projects.
+
+### Task 3: Capture findings
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-04-19-issue-112-findings.md`
+
+- [ ] **Step 1: Write a findings memo**
+
+The file should contain, in under 200 words:
+
+- Answer to Q1 (does `add_project` + folder + sequential at creation reproduce D1?).
+- Answer to Q2: any field that differs between `id_a` and `id_b` in the pre-edit dump (Task 2 Step 3).
+- Answer to Q2 extended: whether the post-edit `sequential` value is actually `true` on both, or only on one.
+- Answer to Q3 (does `add_project` + later `edit_item newSequential: true` reproduce the Dropped flip?). Derive this from `id_a`'s post-edit state recorded in Task 2 Step 5: if `id_a` flipped to `Dropped`, Q3 reproduces; if `id_a` stayed `Active`, Q3 does not reproduce.
+- Decision tree for Phase 2:
+  - **If Q1 reproduces AND Q3 reproduces** (`add_project` at creation flips, AND `add_project` + `edit_item newSequential: true` flips): the bug spans both creation AND post-creation paths shared by `add_project` and `batch_add_items`. Apply Task 5 (shared creation fix) AND Task 5b (shared setSequential fix in `editItem.js` and `batchEditItems.js`).
+  - **If Q1 does NOT reproduce but Q3 DOES**: the bug spans the post-creation setSequential path (and possibly the batch creation path). Apply Task 5b. Then check Task 2 Step 5: if id_b flipped to Dropped at creation, also apply Task 4 (batch creation fix). If id_b did not flip, the batch creation path is fine and Task 4/5 are not needed.
+  - **If Q1 reproduces but Q3 does NOT**: the bug is in the creation site only. Apply Task 4 (if batch-only) or Task 5 (if shared `add_project` + `batch_add_items`). Skip Task 5b.
+  - **If neither Q1 nor Q3 reproduces but Task 2 Step 5 still shows `id_b` flipping** (the known reproducer): the bug is exclusive to the batch creation path. Apply only Task 4.
+
+#### Further investigation (out of plan scope)
+
+If `id_b`'s `sequential` is `false` after an edit that claimed `success: true`, the setter is being silently no-op'd — file a separate issue with the diagnostic data and proceed with Task 4/5 based on Q1 only. Do not block this plan on it.
+
+- [ ] **Step 2: Commit the findings**
+
+```bash
+git add docs/superpowers/plans/2026-04-19-issue-112-findings.md
+git commit -m "docs(#112): record diagnostic findings for batch_add_items sequential bug"
+```
+
+---
+
+## Phase 2: Fix D1
+
+Execute **only one** of Task 4 or Task 5 (the creation-path fix) based on the Phase 1 findings decision tree, AND additionally execute Task 5b if Phase 1 Q3 reproduces. Task 5b (the post-creation setSequential fix) is independent of the Task 4 vs Task 5 choice. If findings are ambiguous (e.g. both code paths sometimes produce Dropped), pause and re-run Phase 1 with explicit logging injected into both scripts (see Task 4 Step 1 logging pattern).
+
+### Task 4: D1 fix, batch-specific (run when the Phase 1 decision tree directs you here: either Q1 does NOT reproduce and id_b still flips at creation, OR Q1 reproduces but Phase 1 findings indicate the creation-time issue is batch-specific rather than shared with add_project)
+
+**Files:**
+- Modify: `src/utils/omnifocusScripts/batchAddItems.js:259-319`
+
+- [ ] **Step 1: Add targeted logging to isolate the mechanism**
+
+Before touching the fix, add debug markers (temporary — removed before commit) to capture post-creation state inside the batch script. Immediately after the existing `newProject.sequential = sequential;` assignment on line 305 (do not remove that line), insert:
+
+```js
+          // TEMP DIAGNOSTIC — remove before commit
+          const postCreateStatus = newProject.status;
+          const postCreateSequential = newProject.sequential;
+          const postCreateTaskSequential = newProject.task ? newProject.task.sequential : null;
+```
+
+Then include these three values in the `projectResult` object returned per project. Run a fresh diagnostic call:
+
+```json
+{
+  "tool": "batch_add_items",
+  "args": {
+    "items": [
+      { "type": "project", "name": "i112-P4-diag-batch-seq", "folderName": "i112-test", "sequential": true }
+    ]
+  }
+}
+```
+
+Then read the `projectResult` from the response. You now know the state the moment after `.sequential = true` — if `status` is already `Dropped` here, the setter itself is flipping status; if `status` is `Active` here but becomes `Dropped` by the time `get_project_by_id` is called, something in the return path or subsequent iteration is mutating it.
+
+Findings from this step dictate the fix mechanism.
+
+- [ ] **Step 2: Apply the fix**
+
+The specific code change depends on Step 1 findings. The two most likely shapes:
+
+**Shape A** — if `newProject.sequential = true` flips status inside batch only (e.g. because `newProject.task` is in a weird state in batch context), set sequential on the task directly and mirror on the project:
+
+```js
+          // Replace line 305:
+          //   newProject.sequential = sequential;
+          // with:
+          if (newProject.task) {
+            newProject.task.sequential = sequential;
+          }
+          newProject.sequential = sequential;
+```
+
+**Shape B** — if the flip happens regardless but is triggered by a specific property-ordering interaction (e.g. setting sequential BEFORE the folder container is fully settled), reorder: move the `sequential` assignment to the very end of the project branch, AFTER tags and tempId registration (currently the last assignment before the result push):
+
+Move line 305 (the `newProject.sequential = sequential;` assignment) to just before line 321 (`const projectResult = {...}`).
+
+Pick the shape that Step 1's diagnostic directly supports. Do not guess.
+
+- [ ] **Step 3: Remove the temporary diagnostic markers from Step 1**
+
+Delete the three `postCreate*` lines and the corresponding fields from `projectResult`.
+
+- [ ] **Step 4: Build and verify**
+
+```bash
+npm run build
+```
+
+Verify by running: `batch_add_items` with one project (`folderName: "i112-test"`, `sequential: true`), capture the returned id, then `edit_item` with `newSequential: true` on that id, then `get_project_by_id` to dump state. Expected: status `Active`, sequential `true` at both dumps. Clean up via `remove_item` on the captured id.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/omnifocusScripts/batchAddItems.js
+git commit -m "fix(#112): prevent batch_add_items project from flipping to Dropped when sequential is set"
+```
+
+### Task 5: D1 fix, shared creation path (run only if Q1 reproduces, i.e., add_project with sequential at creation DOES flip)
+
+**Files:**
+- Modify: `src/utils/omnifocusScripts/addProject.js:107` and `src/utils/omnifocusScripts/batchAddItems.js:305`
+
+- [ ] **Step 1: Apply the sequential-via-task fix to both scripts**
+
+In `addProject.js`, replace line 107:
+
+```js
+// Before:
+newProject.sequential = sequential;
+
+// After:
+if (newProject.task) {
+  newProject.task.sequential = sequential;
+}
+newProject.sequential = sequential;
+```
+
+Apply the identical replacement at `batchAddItems.js:305`.
+
+Rationale (only valid if Phase 1 findings show that `project.task.sequential` is the state the UI reads): `omnifocusDump.js:64` reads `project.task.sequential`, not `project.sequential`. Writing both keeps Project's internal properties consistent regardless of which OmniFocus code path observes them.
+
+- [ ] **Step 2: Build and verify**
+
+```bash
+npm run build
+```
+
+Re-run **both** Phase 1 Task 1 (add_project repro) and Task 2 (batch repro). Expected: no project ends up Dropped.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/omnifocusScripts/addProject.js src/utils/omnifocusScripts/batchAddItems.js
+git commit -m "fix(#112): write sequential to project.task to prevent status flip to Dropped"
+```
+
+### Task 5b: D1 fix — extend to setSequential branches (run only if Phase 1 Q3 reproduces)
+
+**Files:**
+- Modify: `src/utils/omnifocusScripts/editItem.js:291-294` (the `args.newSequential !== undefined` block)
+- Modify: `src/utils/omnifocusScripts/batchEditItems.js:329-332` (the `edit.newSequential !== undefined` block)
+
+This task runs only if Phase 1 Q3 reproduced the Dropped flip via `add_project + edit_item newSequential: true` and/or via `batch_edit_items newSequential: true` on a batch-created project. It applies the same sequential-via-task fix from Task 5 to the post-creation set paths.
+
+**This task is additive to Task 4 / Task 5, not a substitute.** Apply whichever creation-path variant (Task 4 Shape A, Task 4 Shape B, or Task 5) the Phase 1 decision tree directed, then also apply this task if Q3 reproduces. The two fixes operate on different files (creation in `addProject.js`/`batchAddItems.js`, post-creation in `editItem.js`/`batchEditItems.js`) and the `task.sequential = value; project.sequential = value;` pattern is idempotent, so stacking them is safe.
+
+- [ ] **Step 1: Apply the sequential-via-task fix to both setSequential branches**
+
+In `editItem.js`, locate the `args.newSequential !== undefined` block at lines 291–294 (currently writes only `foundItem.sequential = args.newSequential`). Replace it with:
+
+```js
+// Before:
+if (args.newSequential !== undefined) {
+  foundItem.sequential = args.newSequential;
+  changedProperties.push("sequential");
+}
+
+// After:
+if (args.newSequential !== undefined) {
+  if (foundItem.task) { foundItem.task.sequential = args.newSequential; }
+  foundItem.sequential = args.newSequential;
+  changedProperties.push("sequential");
+}
+```
+
+```js
+// For batchEditItems.js (note: identifier is `edit.newSequential`, not `args.newSequential`):
+if (edit.newSequential !== undefined) {
+  if (foundItem.task) {
+    foundItem.task.sequential = edit.newSequential;
+  }
+  foundItem.sequential = edit.newSequential;
+  changedProperties.push("sequential");
+}
+```
+
+Apply the batch-specific replacement above at `batchEditItems.js:329-332`.
+
+- [ ] **Step 2: Build and verify**
+
+```bash
+npm run build
+```
+
+Run the R5 verification procedure inline (do not skip ahead to Phase 5): use `batch_add_items` to create one project (`folderName: "i112-test"`, no sequential), capture the returned id, call `edit_item` with `newSequential: true` on that id, then `get_project_by_id`. Expected: status `Active`, sequential `true`. If Q3 reproduced (i.e., the `add_project` + `edit_item newSequential: true` path also flipped to Dropped), re-run that exact path and confirm it now stays `Active`. Clean up both projects via `remove_item` using their captured ids.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/omnifocusScripts/editItem.js src/utils/omnifocusScripts/batchEditItems.js
+git commit -m "fix(#112): apply sequential-via-task fix to setSequential branches in editItem and batchEditItems"
+```
+
+---
+
+## Phase 3: Fix D2 — `newProjectStatus: "active"` can't recover a Dropped project
+
+This phase is independent of Phase 2. Even after Phase 2 lands, we still need recovery to work for any user who already has Dropped projects from the pre-fix version.
+
+### Task 6: Reproduce D2 deterministically
+
+**Files:** None modified.
+
+- [ ] **Step 1: Create a project and intentionally drop it**
+
+```json
+{ "tool": "add_project", "args": { "name": "i112-P3-drop-recover", "folderName": "i112-test" } }
+```
+
+Record `projectId`. Then:
+
+```json
+{ "tool": "edit_item", "args": { "itemType": "project", "id": "<projectId>", "newProjectStatus": "dropped" } }
+```
+
+Then:
+
+```json
+{ "tool": "get_project_by_id", "args": { "id": "<projectId>" } }
+```
+
+Expected: `status: "Dropped"`.
+
+- [ ] **Step 2: Attempt recovery via `newProjectStatus: "active"`**
+
+```json
+{ "tool": "edit_item", "args": { "itemType": "project", "id": "<projectId>", "newProjectStatus": "active" } }
+```
+
+Expected response per the bug report: `success: true`, `changedProperties: "status"`.
+
+- [ ] **Step 3: Re-check status**
+
+```json
+{ "tool": "get_project_by_id", "args": { "id": "<projectId>" } }
+```
+
+Per user report: `status` still `"Dropped"`. Confirm this reproduces. If recovery actually works in your environment, STOP — investigate environment differences rather than assume the bug is present.
+
+### Task 7: Patch the status-set path in `editItem.js`
+
+**Files:**
+- Modify: `src/utils/omnifocusScripts/editItem.js:297-309`
+
+- [ ] **Step 1: Update the `active` branch to unconditionally un-drop the project's task**
+
+OmniFocus treats a Dropped project's root task as dropped; assigning `Project.Status.Active` to a project whose task is Dropped appears to be a no-op. The recovery path must mark the task incomplete (lifting the drop) in addition to setting status.
+
+Replace lines 297–309:
+
+```js
+// Before:
+    if (itemType === 'project' && args.newProjectStatus !== undefined) {
+      if (args.newProjectStatus === 'active') {
+        foundItem.status = Project.Status.Active;
+      } else if (args.newProjectStatus === 'completed') {
+        foundItem.markComplete();
+      } else if (args.newProjectStatus === 'dropped') {
+        // Projects use status property, not drop() method
+        foundItem.status = Project.Status.Dropped;
+      } else if (args.newProjectStatus === 'onHold') {
+        foundItem.status = Project.Status.OnHold;
+      }
+      changedProperties.push("status");
+    }
+```
+
+```js
+// After:
+    if (itemType === 'project' && args.newProjectStatus !== undefined) {
+      if (args.newProjectStatus === 'active') {
+        // Only un-drop if currently Dropped — avoid unintended side effects on OnHold/Completed -> Active.
+        if (foundItem.status === Project.Status.Dropped &&
+            foundItem.task && typeof foundItem.task.markIncomplete === 'function') {
+          try { foundItem.task.markIncomplete(); } catch (e) { /* ignore if already incomplete */ }
+        }
+        foundItem.status = Project.Status.Active;
+      } else if (args.newProjectStatus === 'completed') {
+        foundItem.markComplete();
+      } else if (args.newProjectStatus === 'dropped') {
+        // Projects use status property, not drop() method
+        foundItem.status = Project.Status.Dropped;
+      } else if (args.newProjectStatus === 'onHold') {
+        foundItem.status = Project.Status.OnHold;
+      }
+
+      // Verify the status change actually stuck; if not, surface an error.
+      const expectedStatus = {
+        'active': Project.Status.Active,
+        'dropped': Project.Status.Dropped,
+        'onHold': Project.Status.OnHold
+      }[args.newProjectStatus];
+      if (expectedStatus !== undefined && foundItem.status !== expectedStatus) {
+        return JSON.stringify({
+          success: false,
+          error: `Status change to "${args.newProjectStatus}" did not persist (project is still ${foundItem.status === Project.Status.Dropped ? 'Dropped' : 'in previous state'})`
+        });
+      }
+
+      changedProperties.push("status");
+    }
+```
+
+Note: the empty `catch` on `markIncomplete` is intentional and scoped (the method may throw on non-droppable tasks; that's not a recovery failure). The post-set verification check below covers the three direct-assignment branches (`active`, `dropped`, `onHold`) and surfaces an error if the assignment did not persist. The `completed` branch is intentionally not verified here because `markComplete()` is a method call (not a property assignment), and we do not have empirical confirmation that the project's `status` synchronously equals `Project.Status.Done` after the call returns. If a future investigation confirms synchronous behaviour, `'completed': Project.Status.Done` can be added to the map.
+
+- [ ] **Step 2: Build and verify D2 recovery works**
+
+```bash
+npm run build
+```
+
+Re-run Task 6 Steps 1–3 on a fresh project. Expected after Step 3: `status: "Active"`.
+
+- [ ] **Step 3: Verify D2 recovery works on projects affected by D1 pre-fix**
+
+If you still have a separate git checkout (or worktree) of the pre-fix branch, create a D1-affected project there using the buggy code, then check out the fix branch and run recovery against that project. Otherwise, manually drop a project (Task 6 Step 1), switch it back (Task 6 Step 2), and confirm recovery works.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/omnifocusScripts/editItem.js
+git commit -m "fix(#112): make newProjectStatus: active actually recover Dropped projects"
+```
+
+### Task 8: Mirror the D2 fix into `batchEditItems.js`
+
+**Files:**
+- Modify: `src/utils/omnifocusScripts/batchEditItems.js:334-346`
+
+- [ ] **Step 1: Apply the identical status-branch patch**
+
+The block at `batchEditItems.js:334-346` is structurally identical to `editItem.js:297-309`. Apply the same replacement from Task 7 Step 1, adjusted for the batch context (the error return becomes a `results.push({success: false, ...}); continue;` pattern matching the surrounding batch-iteration style rather than a direct `return`).
+
+Specifically, in the batch version, replace the status block with the code below. (Verified: `batchEditItems.js` declares `const changedProperties = []` per loop iteration, so the same identifier is correct here.)
+
+```js
+        if (itemType === 'project' && edit.newProjectStatus !== undefined) {
+          if (edit.newProjectStatus === 'active') {
+            // Only un-drop if currently Dropped — avoid unintended side effects on OnHold/Completed -> Active.
+            if (foundItem.status === Project.Status.Dropped &&
+                foundItem.task && typeof foundItem.task.markIncomplete === 'function') {
+              try { foundItem.task.markIncomplete(); } catch (e) { /* ignore if already incomplete */ }
+            }
+            foundItem.status = Project.Status.Active;
+          } else if (edit.newProjectStatus === 'completed') {
+            foundItem.markComplete();
+          } else if (edit.newProjectStatus === 'dropped') {
+            foundItem.status = Project.Status.Dropped;
+          } else if (edit.newProjectStatus === 'onHold') {
+            foundItem.status = Project.Status.OnHold;
+          }
+
+          const expectedStatus = {
+            'active': Project.Status.Active,
+            'dropped': Project.Status.Dropped,
+            'onHold': Project.Status.OnHold
+          }[edit.newProjectStatus];
+          if (expectedStatus !== undefined && foundItem.status !== expectedStatus) {
+            results.push({
+              success: false,
+              id: originalId,
+              name: originalName,
+              error: `Status change to "${edit.newProjectStatus}" did not persist`
+            });
+            continue;
+          }
+
+          changedProperties.push("status");
+        }
+```
+
+- [ ] **Step 2: Build and verify**
+
+```bash
+npm run build
+```
+
+Create a dropped project (Task 6 Step 1), then recover via `batch_edit_items` (single edit in array):
+
+```json
+{
+  "tool": "batch_edit_items",
+  "args": {
+    "edits": [
+      { "itemType": "project", "id": "<projectId>", "newProjectStatus": "active" }
+    ]
+  }
+}
+```
+
+Then `get_project_by_id`. Expected: `status: "Active"`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/omnifocusScripts/batchEditItems.js
+git commit -m "fix(#112): apply status-recovery fix to batch_edit_items"
+```
+
+---
+
+## Phase 4: Fix D3 — `add_project` folderName case sensitivity
+
+### Task 9: Normalize folder name matching in `addProject.js`
+
+**Files:**
+- Modify: `src/utils/omnifocusScripts/addProject.js:55-62`
+
+- [ ] **Step 1: Reproduce D3**
+
+Create a folder in OmniFocus named exactly `i112-TestCase`. Call:
+
+```json
+{ "tool": "add_project", "args": { "name": "i112-P4-case-test", "folderName": "i112-testcase" } }
+```
+
+Expected per bug: `success: false, error: "Folder not found with name \"i112-testcase\""`.
+
+- [ ] **Step 2: Apply case-insensitive match**
+
+Replace lines 55–62 of `addProject.js`:
+
+```js
+// Before:
+      if (!container && folderName) {
+        for (const folder of allFolders) {
+          if (folder.name === folderName) {
+            container = folder;
+            break;
+          }
+        }
+      }
+```
+
+```js
+// After:
+      if (!container && folderName) {
+        const folderNameLower = folderName.toLowerCase();
+        for (const folder of allFolders) {
+          if (folder.name.toLowerCase() === folderNameLower) {
+            container = folder;
+            break;
+          }
+        }
+      }
+```
+
+This matches the behaviour already in `batchAddItems.js:72` (`foldersByName.set(f.name.toLowerCase(), f)` populating the lookup map; the lookup itself is at line 278) and in `editItem.js:65`.
+
+- [ ] **Step 3: Build and verify**
+
+```bash
+npm run build
+```
+
+Re-run Step 1. Expected: `success: true`, project created in `i112-TestCase`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/omnifocusScripts/addProject.js
+git commit -m "fix(#112): make add_project folderName lookup case-insensitive (match batch_add_items)"
+```
+
+---
+
+## Phase 5: Full regression verification
+
+Execute the complete issue reproduction matrix and confirm every row now passes. Any row that still fails means the corresponding fix is incomplete.
+
+### Task 10: Run the full test matrix
+
+**Files:** None modified.
+
+- [ ] **Step 1: Execute each row — create, verify, cleanup**
+
+For each of these eight test cases, (a) run the creation call, (b) call `get_project_by_id` and record `status` and `sequential`, (c) `remove_item` the project.
+
+| # | Call | Args | Expected status | Expected sequential |
+|---|------|------|-----------------|---------------------|
+| R1 | `add_project` | name, folderName, sequential:true | Active | true |
+| R2 | `add_project` | name, folderName (no sequential) | Active | false |
+| R3 | `batch_add_items` | 1 project, folderName, sequential:true | Active | true |
+| R4 | `batch_add_items` | 1 project, folderName (no sequential) | Active | false |
+| R5 | `batch_add_items` (no seq) + `edit_item` newSequential:true | — | Active | true |
+| R5b | `batch_add_items` (no seq) + `batch_edit_items` newSequential:true | n/a | Active | true |
+| R6 | `batch_add_items` (seq:true at creation), then `edit_item` newProjectStatus:"dropped", then `edit_item` newProjectStatus:"active" | — | Active (recovered) | true |
+| R7 | `batch_add_items` (seq:true at creation), then `batch_edit_items` newProjectStatus:"dropped", then `batch_edit_items` newProjectStatus:"active" | — | Active (recovered) | true |
+
+Every row must pass. Record any failure with the row number, the actual response, and the `get_project_by_id` output.
+
+- [ ] **Step 2: Case-sensitivity spot-check**
+
+Run: `add_project` with `folderName: "I112-TEST"` (all-caps version of the sandbox folder). Expected: success, created in `i112-test`. Clean up.
+
+- [ ] **Step 3: Sanity-run a handful of other `batch_add_items` scenarios that should be unaffected**
+
+Don't regress existing behaviour. Verify these three still work:
+1. `batch_add_items` with a project **and** a task referencing it via `parentTempId` in the same call → both created, task in project.
+2. `batch_add_items` with a task that references an existing project via `projectName` → task created in project.
+3. `batch_edit_items` that drops a project (`newProjectStatus: "dropped"`) → project becomes Dropped.
+
+All three should behave the same as before the plan's changes.
+
+- [ ] **Step 4: Clean up sandbox**
+
+Remove every `i112-*` project. Leave the `i112-test` folder in place (harmless) or delete it manually if preferred — no automated folder deletion tool exists.
+
+---
+
+## Phase 6: Docs + version bump + PR
+
+### Task 11: Update changelog and version
+
+**Files:**
+- Modify: `package.json` (version only)
+- Modify: `docs/WHATS_NEW.md` (prepend new entry)
+
+- [ ] **Step 1: Bump version from `1.30.7` to `1.30.8`**
+
+Edit `package.json` `"version"` field to `1.30.8`. In `docs/WHATS_NEW.md`, locate the current top-level H1 (which should reflect the previous version) and update its parenthetical version to `(v1.30.8)`. Read the H1 first; do not assume its exact text matches what's quoted here.
+
+- [ ] **Step 2: Add a `WHATS_NEW.md` entry**
+
+Insert the new entry immediately above the existing top H2 (currently `## v1.30.7 ...`). Use the existing file's style: `## v<version> <descriptive title>` with bold sub-section labels (no `### Fixes` heading).
+
+```markdown
+## v1.30.8 Fix batch_add_items sequential+folderName Dropped bug, status recovery, and folder case (Issue #112)
+
+**Sequential + folderName no longer drops projects.** Projects created via `batch_add_items` with `folderName` + `sequential: true` no longer end up with Dropped status. The fix also applies when `sequential` is set later via `edit_item` or `batch_edit_items`.
+
+**Dropped projects can now be recovered.** `edit_item` and `batch_edit_items` with `newProjectStatus: "active"` now correctly restore a Dropped project to Active. Previously the call reported success but the status did not persist. Any Dropped project (including ones created before this fix) can now be recovered.
+
+**Folder name lookup is case-insensitive in `add_project`.** Now consistent with `batch_add_items` and `edit_item`.
+```
+
+- [ ] **Step 3: Update `README.md` if tool behaviour changed visibly**
+
+If the MCP tool argument shapes did not change (they didn't — all fixes are internal), no README update is needed. Verify by grepping `README.md` for `batch_add_items` and confirming no documented behaviour contradicts the fix.
+
+- [ ] **Step 4: Build once more and commit**
+
+```bash
+npm run build
+git add package.json docs/WHATS_NEW.md
+git commit -m "chore(#112): bump version to 1.30.8 and document fixes"
+```
+
+### Task 12: Open pull request
+
+**Files:** None.
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin fix/issue-112-batch-add-sequential-dropped
+```
+
+- [ ] **Step 2: Create PR referencing the issue**
+
+```bash
+gh pr create --title "fix: Resolve issue #112 — batch_add_items sequential+folderName Dropped bug + status recovery + folder case" --body "$(cat <<'EOF'
+## Summary
+
+Closes #112.
+
+- D1: `batch_add_items` + `folderName` + `sequential=true` (at creation or later) no longer flips projects to Dropped.
+- D2: `edit_item` / `batch_edit_items` with `newProjectStatus: "active"` now actually recovers Dropped projects; previously reported success but state did not persist. Status-set paths now verify the change stuck and surface an error if it did not.
+- D3: `add_project` now matches `folderName` case-insensitively, consistent with other tools.
+
+## Test plan
+
+Manual test matrix (Phase 5 of the implementation plan) — eight rows from the issue plus three regression scenarios. All passed in the author's environment.
+
+- [ ] Matrix R1: `add_project` folder+seq:true → Active/true
+- [ ] Matrix R2: `add_project` folder only → Active/false
+- [ ] Matrix R3: `batch_add_items` folder+seq:true → Active/true
+- [ ] Matrix R4: `batch_add_items` folder only → Active/false
+- [ ] Matrix R5: `batch_add_items` then `edit_item` newSequential:true → Active/true
+- [ ] Matrix R5b: `batch_add_items` then `batch_edit_items` newSequential:true → Active/true
+- [ ] Matrix R6: drop then recover via `edit_item` newProjectStatus:"active" → Active
+- [ ] Matrix R7: drop then recover via `batch_edit_items` newProjectStatus:"active" → Active
+- [ ] Case: `folderName: "I112-TEST"` on `add_project` → succeeds
+- [ ] Regression: `parentTempId`, cross-project `projectName`, drop via batch_edit_items
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Return the PR URL**
+
+Record the URL for the user.
+
+---
+
+## Self-review checklist
+
+Before declaring the plan complete, run these checks mentally against the plan above:
+
+1. **Spec coverage** — the issue raises three distinct defects (D1 primary, D1 recovery-broken secondary = D2, folder case-sensitivity = D3). All three have dedicated phases (2, 3, 4) and all eight matrix rows are verified in Phase 5. ✅
+
+2. **Placeholder scan** — no "TBD", "add appropriate error handling", "similar to Task N" (all code blocks are fully expanded). Task 4 Step 2 explicitly names two concrete fix shapes and instructs to pick based on Phase 1 findings rather than hand-wave. ✅
+
+3. **Type consistency** — `Project.Status.Active`, `Project.Status.Dropped`, `Project.Status.OnHold`, `foundItem.task.markIncomplete()` used consistently across Tasks 7 and 8. Tool argument names (`newSequential`, `newProjectStatus`, `folderName`, `id`) match schemas in the primitives I've read (`addProject.ts`, `batchAddItems.ts`, `editItem.ts`). ✅
+
+4. **Unknowns handled** — Phase 1 Task 3 Step 1 explicitly branches Phase 2 based on empirical findings rather than assuming a root cause. If the bug does not reproduce in the engineer's environment, Phase 1 stops with a report rather than proceeding on a false premise. ✅

--- a/docs/superpowers/plans/2026-04-19-issue-112-fix.review.md
+++ b/docs/superpowers/plans/2026-04-19-issue-112-fix.review.md
@@ -1,0 +1,161 @@
+# Review Summary: 2026-04-19-issue-112-fix.md
+
+**Reviewed:** 2026-04-19
+**Rounds:** 3
+**Final status:** Accepted (user finalised after Round 3; one escalation accepted as status-quo per Option B)
+
+---
+
+## Round 3 — 2026-04-19T19:59:00-0700
+
+### Cycle Summary
+Cycles: 1 (cycle 2 skipped per user time pressure), Findings: ~17 (post-merge), Fixed (auto): 14, Escalated: 1
+
+### Escalations
+
+**1. Phase 1 Q3 doesn't empirically test `batch_edit_items newSequential` (3 lenses agreed)**
+- Issue: Q3 only tests `add_project + edit_item newSequential: true` via id_a in Task 2 Step 5. Task 5b's gating clause references both `edit_item` and `batch_edit_items`, but only one is verified by Phase 1. We patch `batchEditItems.js` defensively assuming shared bug shape.
+- Options: A) Add Task 2 Step 4b to test batch_edit_items empirically, expand Q3. B) Status quo: defensive mirror patch, R5b regression-tests result. C) Defer batchEditItems portion to follow-up.
+- User decision: **B** (status quo). Plan unchanged. R5b in Phase 5 will catch any post-fix failure.
+
+### Cycle 1 auto-fixes (14)
+
+1. **Task 7 expectedStatus map:** REMOVED `'completed': Project.Status.Done` (Round 2 addition). `markComplete()` is a method call, not synchronous property assignment; verification would have spuriously broken the working completed path.
+2. **Task 8 expectedStatus map:** Same removal in batchEditItems version.
+3. **Task 7 Note:** Updated to explain why `completed` is intentionally unverified, with note that future empirical confirmation could re-enable it.
+4. **Phase 2 preamble:** Clarified Task 5b runs independently of the Task 4 vs Task 5 choice ("execute only one of Task 4 or Task 5 AND additionally execute Task 5b if Q3 reproduces").
+5. **Task 4 gating clause:** Updated to match the decision tree (multi-condition: Q1 NOT reproducing AND id_b flips, OR Q1 reproduces but issue is batch-specific).
+6. **Task 3 decision tree second branch:** Provided explicit criterion (check Task 2 Step 5 to determine if Task 4 also applies).
+7. **Task 5b:** Added explicit batch-version code block (using `edit.newSequential`) to avoid silent no-op bug from copy-pasting the editItem version.
+8. **Phase 5 matrix:** Added R5b row (`batch_add_items` no-seq + `batch_edit_items newSequential:true → Active/true`). Updated count from "seven" to "eight" in three places. Added R5b checklist line to PR body.
+9. **Phase 6 Task 11:** Changed H1 update to "read first" pattern (don't assume current literal text).
+10. **Phase 0 Step 4:** Clarified substitute-name scope (only folder name in folderName arguments; project prefixes don't change).
+11. **D1 inventory:** Clarified attachment ("on a project created via either add_project or batch_add_items").
+12. **Task 4 Step 1:** Inlined diagnostic JSON (no more "Step 2 with sequential added").
+13. **Task 4 Step 4:** Inlined verification JSON.
+14. **Task 8:** Changed hedge to positive statement (changedProperties identifier verified).
+
+### Findings by Cycle (Cycle 1)
+
+| Lens | Findings | Applied | Escalated | Notes |
+|------|----------|---------|-----------|-------|
+| Ambiguity | 13 | 8 | 0 (5 cosmetic accepted) | Most pointed at gating clause / decision tree consistency. |
+| Accuracy | 0 | 0 | 0 | Clean! All line numbers, snippets, version, H1 verified. |
+| Goal Adherence | 8 | 4 | 1 (Q3 expansion → B) | Strong consensus on Phase 2 preamble + R5b additions. |
+| Feasibility | 8 | 4 | 0 (3 confirmed-correct, 1 cosmetic accepted) | Code-snippet inlining + identifier verification. |
+
+### Round-over-round delta
+Round 1 cycle 1: ~24 findings → Round 2 cycle 1: ~14 findings → Round 3 cycle 1: ~17 findings. Round 3 includes new findings introduced by Round 1/2's structural changes (Task 5b additions, expectedStatus map). Net trajectory: substantial structural improvements, with each round refining the previous round's additions.
+
+---
+
+## Round 2 — 2026-04-19T18:50:00-0700
+
+### Cycle Summary
+Cycles: 1 (cycle 2 skipped per user time pressure), Findings: ~19 (post-merge ~14), Fixed (auto): 8, Escalated: 1
+
+### Escalations
+
+**1. Task 2b is redundant with Task 2 Steps 4-5 (Feasibility lens flagged)**
+- Issue: Task 2 already creates id_a via add_project (no seq) and tests Q3 in Step 4-5. Task 2b duplicated this work. Cascading issues: Task 2 Step 5 falsely asserted "id_a should stay Active" (contradicting Q3), decision tree third branch self-contradicted, Task 4/5 headings ambiguous.
+- Options: A) Delete Task 2b. B) Keep as confirmation. C) Restructure to test something different.
+- User decision: **A** (delete). Editing agent restructured Phase 1: Task 2b removed, Task 3 decision tree rewritten as 4-branch, Task 2 Step 5 assertion fixed, Task 4/5 headings clarified.
+
+### Cycle 1 auto-fixes (8)
+
+1. **Goal text:** Disambiguated "any sequential=true path" wording.
+2. **Phase 0 Step 4:** Clarified destruction-risk warning to apply only to bulk-deletion of unknown items.
+3. **Task 5b Step 2:** Clarified "Q3 also showed" wording.
+4. **Defect inventory + Task 8:** Corrected batchEditItems.js line range from 335-346 to 334-346.
+5. **Task 7 expectedStatus map:** Added `'completed': Project.Status.Done` (NOTE: reversed in Round 3 due to regression risk).
+6. **Task 8 expectedStatus map:** Same addition (also reversed in Round 3).
+7. **Task 7 Note:** Updated to reflect verification covers all four branches (also reversed in Round 3).
+8. **Task 5b Step 2:** Inlined R5 verification procedure (no longer forward-references Phase 5).
+
+### Findings by Cycle (Cycle 1)
+
+| Lens | Findings | Applied | Escalated |
+|------|----------|---------|-----------|
+| Ambiguity | 9 | 4 | 5 (covered by Resolution A) |
+| Accuracy | 3 | 2 | 1 (covered by Resolution A) |
+| Goal Adherence | 0 | 0 | 0 |
+| Feasibility | 7 | 2 | 1 (Resolution A); 4 cosmetic accepted |
+
+---
+
+## Round 1 — 2026-04-19T18:47:00-0700
+
+### Cycle Summary
+Cycles: 2, Findings: ~40 (post-merge), Fixed (auto): 14, Escalated: 19
+
+### Escalations
+
+**1. D1 fix surface gap (Goal Adherence + Feasibility, both rounds)**
+- Issue: Plan's defect inventory said D1 includes "at creation OR later via edit_item", but Phase 2 only modified addProject.js + batchAddItems.js. Phase 5 R5 verified the edit_item path but no Phase 2 task made it pass.
+- Options: A) Add Task 4b/5b to also patch setSequential branches. B) Narrow D1 scope and defer. C) Add Phase 1 Q3 to test edit_item path empirically.
+- User decision: **C** (empirical-first matches plan's existing philosophy). Editing agent added Q3 to Phase 1, Task 2b (edit-path diagnostic, later removed in Round 2), Task 3 ternary decision tree, Task 5b (setSequential fix conditional on Q3).
+
+**2-10. Group A (medium structural — 3 items) + Group B (clarifying wording — 6 items)**
+All approved in bulk:
+- Phase 0 Step 4 deletion safety (abort instead of auto-delete)
+- Task 7 markIncomplete unconditional (gate on Project.Status.Dropped)
+- WHATS_NEW.md format/style (match existing file conventions)
+- "Between phases" cleanup (made explicit)
+- D1 inventory wording (tightened)
+- Phase 1 Task 3 hypothetical defect (moved to "Further investigation" subsection)
+- Task 8 changedProperties (verification note added)
+- Phase 1 Task 2 Step 4 success precondition (made explicit)
+- "Stop and report to the user" (clarified)
+
+**11-19. Group C (~9 low-impact items) — accepted as-is**
+- Task 5 "identical replacement" wording, Task 7 expectedStatus map omits 'completed' (intentional pre-Round 2), various wordsmithing items, D2/D3 "no empirical diagnosis" parity, D3 case-variant folder collision, "appears to be" hedging, Move line 305 line-shift, Task 4 Phase 5 add_project edit row (covered by Resolution 1's Option C).
+
+### Cycle 1 auto-fixes (9)
+1. Phase 0 Step 2: disambiguated path
+2. Phase 1 Task 1 Step 2: sharpened bug-confirming language
+3. Task 4 Step 1: disambiguated insertion location
+4. Task 4 Shape B: disambiguated singular line
+5. Task 7: sharpened "every other failure mode" scope
+6. Task 7 Step 3: clarified backup type
+7. Task 9 Step 2: corrected line citation (batchAddItems.js:278 → :72)
+8. Phase 5 R6 + new R7: disambiguated `+` separators, added batch_edit_items recovery row
+9. Task 11 Step 2: corrected insertion direction
+
+### Cycle 2 auto-fixes (5)
+10. Phase 5 prose: "six test cases" → "seven test cases"
+11. Self-review checklist: "all six matrix rows" → "all seven matrix rows"
+12. PR body: "six rows" → "seven rows", added R7 checkbox
+13. Task 7 Before/After code blocks: added missing comment in dropped branches
+14. Phase 1 Task 2 Step 3: corrected get_project_by_id field names to match actual API
+
+### Findings by Cycle
+
+| Cycle | Ambiguity | Accuracy | Goal | Feasibility | Total |
+|-------|-----------|----------|------|-------------|-------|
+| 1 | 13 | 12 | 5 | 7 | 37 |
+| 2 | 10 | 7 | 5 | 7 | 29 |
+
+---
+
+## Final session totals
+
+- **Rounds:** 3
+- **Lens-cycles run:** 4 (R1C1, R1C2, R2C1, R3C1)
+- **Total findings (across all rounds, post-merge):** ~80
+- **Auto-applied fixes:** 36 (R1C1: 9, R1C2: 5, R2C1: 8, R3C1: 14)
+- **Escalations resolved by user:** 3 substantive decisions (Resolution 1: Option C; Resolution A: delete Task 2b; Round 3 Q3: Option B status quo)
+- **Document line count:** 690 → 776 lines (gained Q3, Task 5b, R5b, R7, expanded code blocks, and clarification text; offset by Task 2b deletion)
+- **Major structural improvements:**
+  - Phase 1 now tests Q3 (post-creation edit path) via id_a, not as separate task
+  - Phase 2 has Task 5b for setSequential fix (independent of Task 4/Task 5 choice)
+  - Phase 5 has R5b + R7 for batch_edit_items coverage
+  - Defect inventory wording precise about which paths are affected
+  - WHATS_NEW.md format aligned with existing file conventions
+  - Decision tree internally consistent across all 4 branches
+
+**Outstanding hedges (accepted as-is):**
+- Task 5 rationale conditional ("only valid if Phase 1 findings show...") still depends on data Phase 1 doesn't separately capture
+- Task 4 Shape A mechanism opaque (appropriate hedge for hypothesis under test)
+- Project.Status.Done used in note text but verification map intentionally excludes 'completed' branch
+
+These are documented in the plan and acceptable given the empirical-first philosophy.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.30.7",
+  "version": "1.30.8",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/utils/omnifocusScripts/addProject.js
+++ b/src/utils/omnifocusScripts/addProject.js
@@ -53,8 +53,9 @@
 
       // Fall back to name lookup if ID not found or not provided
       if (!container && folderName) {
+        const folderNameLower = folderName.toLowerCase();
         for (const folder of allFolders) {
-          if (folder.name === folderName) {
+          if (folder.name.toLowerCase() === folderNameLower) {
             container = folder;
             break;
           }


### PR DESCRIPTION
## Summary

Partial fix for #112 — addresses the folder name case sensitivity defect (D3 in the issue). The other two reported defects could not be reproduced in diagnostic testing; details are in an issue comment requesting fresh steps-to-reproduce.

- **D3 fix:** `add_project` now matches `folderName` case-insensitively. Previously `add_project` required exact-case match while `batch_add_items` and `edit_item` already matched case-insensitively. Source asymmetry resolved in `src/utils/omnifocusScripts/addProject.js` by mirroring the `.toLowerCase()` pattern already used in `batchAddItems.js:72` and `editItem.js:65`.
- **D1 (`batch_add_items` + sequential → Dropped) and D2 (`newProjectStatus: "active"` recovery):** Not reproduced across four D1 variants (including a sequential project with child tasks) and one D2 drop-then-recover cycle via both `edit_item` and `batch_edit_items`. Source code at the cited lines is unchanged from baseline. Null findings recorded in `docs/superpowers/plans/2026-04-19-issue-112-findings.md`.

The implementation plan (`2026-04-19-issue-112-fix.md`) and its 3-round review (`.review.md`) are included in this PR as the decision trail that led to the D3-only scope.

## Test plan

- [x] D3 reproduced pre-fix: `add_project folderName: "i112-testcase"` against `i112-TestCase` folder → `Folder not found` error
- [x] D3 fix verified (mixed case): same call post-fix → project created in `i112-TestCase`
- [x] D3 fix verified (all caps): `add_project folderName: "I112-TEST"` against `i112-test` folder → resolved correctly
- [x] Regression: `batch_add_items` task via `projectName` reference → task landed in project
- [x] Regression: `batch_edit_items` drop then recover via `newProjectStatus` → project Active, child task preserved
- [x] Phase 1 diagnostic matrix (four D1 variants + one D2 cycle) — all clean, no speculative fixes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)