### PR TITLE
fix(#110): surface metadata read errors in project listing tools (Phase 2)

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,18 @@
-# OmniFocus MCP Server - What's New (v1.30.9)
+# OmniFocus MCP Server - What's New (v1.30.10)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.30.10 Surface metadata read errors in project listing tools (Issue #110, Phase 2)
+
+**`list_projects` and `get_projects_for_review` no longer silently swallow optional-field read errors.** Previously, if a project's task count, folder info, or review date/interval couldn't be read, the `catch` block discarded the error and the field silently fell back to `0`/`null` — so a partial result was indistinguishable from a complete one. These tools now count such failures and append a **⚠️ Processing Warnings** section (e.g. "2 details could not be read; affected fields may show as '-', 0, or null") with up to 3 sample messages, and emit a server-side `log.warn`.
+
+**Impact:** Error-free calls produce identical output to before — the warning only appears when a field actually failed to read. The projects themselves are still listed; this only adds visibility into incomplete data.
+
+**Also fixed (`get_projects_for_review`):** each project now correctly shows its **folder**. The script was reading a non-existent `project.folder` property (always `undefined`) instead of `project.parentFolder`, so the folder line was silently always blank. This was a wrong-property bug, not a swallowed exception, so it was invisible to the error-surfacing above — found during Phase 2 testing. `list_projects` was never affected (it already used `parentFolder`).
+
+**Pattern.** This reuses the `processingErrors` mechanism from v1.30.7 (issue #104/#109), generalized with a new `metadataErrors` category in `formatProcessingWarnings()`. The `processingErrors: { metadataErrors, samples }` contract is the template for the remaining #110 phases (`getProjectByName.js`, `getFolderByName.js`, `getTaskByIdOrName.js`, `editItem.js`). Defensive folder-traversal guards that return a safe default (`isInDroppedFolder`/`isEffectivelyDropped`) are intentionally left uncounted.
+
+---
 
 ## v1.30.9 Remove dead dump_database code (Issue #110)
 

--- a/docs/test-plans/issue-110-phase2-smoke-test.md
+++ b/docs/test-plans/issue-110-phase2-smoke-test.md
@@ -1,0 +1,209 @@
+# Smoke Test — Issue #110 Phase 2 (project-listing error surfacing)
+
+**Branch:** `fix/issue-110-phase2-project-listing-errors`
+**Version under test:** `1.30.10`
+**Tools affected:** `list_projects`, `get_projects_for_review`
+**Run in:** a Claude Code (or other MCP client) session connected to **OmniFocus** on macOS.
+
+---
+
+## What changed (context for the tester)
+
+These two tools used to swallow errors when an optional field couldn't be read
+(`} catch (e) {}`). A project's task count / folder / review date would silently
+fall back to `0`/`null`, so a partial result looked identical to a complete one.
+
+Now, when such a read fails, the tool **counts** it, captures up to 3 sample
+messages, and appends a `⚠️ Processing Warnings` section to its output (and
+emits a server-side `log.warn`). **The projects are still listed** — this only
+adds *visibility* into incomplete data.
+
+The central thing this smoke test confirms is the **regression case**: in a
+healthy database, *nothing fails to read*, so the output must be **identical to
+before — no warning section at all.** The warning path itself is exotic and not
+expected to trigger on a normal database (its rendering is already verified by an
+automated check, see "Notes" at the bottom).
+
+**Also bundled (v1.30.10):** a folder-property fix in `get_projects_for_review`.
+It previously read a non-existent `project.folder` (always `undefined`) instead of
+`project.parentFolder`, so the per-project folder line was *always* blank. This
+was a wrong-property bug, not a swallowed exception, so the error-surfacing above
+does not catch it — TC4/TC5 below verify the folder now appears. `list_projects`
+was never affected.
+
+---
+
+## Setup (do this once before the test cases)
+
+1. **Build this branch** so the MCP server runs v1.30.10:
+   ```bash
+   cd /Users/mojen/dev/of-mcp
+   git checkout fix/issue-110-phase2-project-listing-errors
+   npm run build
+   ```
+2. **Point your MCP client at this build** (`dist/server.js` in this repo) and
+   **restart the session** so it loads the new build. If you normally use the
+   published/`main` server, switch it to this repo's `dist/server.js` for the test.
+3. Have OmniFocus running with your normal database (or any database that has at
+   least a few projects, ideally some inside folders and some marked for review).
+
+---
+
+## TC1 — Version gate (must pass before anything else)
+
+**Why:** confirms you're testing this branch's build, not an older one.
+
+**Do:** ask Claude to run the `get_server_version` tool.
+
+**Expect:** the returned JSON has `"version": "1.30.10"`.
+
+- [ ] **PASS** — version is `1.30.10`
+- [ ] **FAIL** — any other version (stop; you're testing the wrong build — revisit Setup)
+
+---
+
+## TC2 — `list_projects` happy path (primary regression check)
+
+**Do:** ask Claude: *"List my projects"* (i.e. call `list_projects` with no arguments).
+
+**Expect:**
+- A normal projects table with columns: `Name | Status | Tasks | Next Review | Folder`.
+- A `**Project IDs:**` list below the table.
+- A `Found **N** active project(s):` count line.
+- **No `⚠️ Processing Warnings` section anywhere in the output.**
+
+**Pass criteria:** output is structurally identical to what previous versions
+produced, and there is **no** warning section.
+
+- [ ] **PASS** — normal output, no warning section
+- [ ] **FAIL** — warning section present, OR table/IDs/count missing or malformed (record the output)
+
+---
+
+## TC3 — `list_projects` across filters (instrumentation didn't break other paths)
+
+Run each of these and confirm normal output with **no warning section**:
+
+1. *"List all my projects including completed and dropped"* → `list_projects` with `status: "all"`.
+2. *"List projects in the folder `<a real folder name>`"* → `list_projects` with `folderName: "<folder>"`.
+3. *"List on-hold projects"* → `list_projects` with `status: "onHold"`.
+
+**Expect:** each returns its filtered table correctly; task counts, folders, and
+next-review dates are populated where they exist; no `⚠️ Processing Warnings`.
+
+- [ ] **PASS** — all three return normal, correctly-filtered output, no warnings
+- [ ] **FAIL** — any returns a warning section, wrong filtering, or broken output (note which)
+
+---
+
+## TC4 — `get_projects_for_review` happy path (primary regression check)
+
+**Do:** ask Claude: *"Which projects need review?"* → `get_projects_for_review`.
+
+**Expect either:**
+- A `📋 Projects Needing Review (N)` list where each entry shows Status, Remaining
+  Tasks, Review Interval, Next/Last Review dates — and **no** `⚠️ Processing
+  Warnings` section; **or**
+- `No projects need review at this time.` if nothing is currently due (also a valid PASS).
+
+**Folder line (fixed in 1.30.10):** projects that live **inside a folder** must now
+show a `• Folder: <name>` line; root-level projects correctly show no folder line.
+Before 1.30.10 this line never appeared for *any* project (the script read a
+non-existent `project.folder` property — see "Notes"). Cross-check against
+`list_projects` (TC2): a project shown under a folder there must also show that
+folder here.
+
+**Pass criteria:** normal review output (or the empty-state message); no warning
+section; **foldered projects now show their folder.**
+
+- [ ] **PASS** — normal review list (or empty-state); foldered projects show `• Folder:`; no warning section
+- [ ] **FAIL** — warning section present, folder line missing for a project you know is in a folder, or fields missing (record output)
+
+---
+
+## TC5 — `get_projects_for_review` with on-hold included
+
+**Do:** ask Claude: *"Which projects need review, including on-hold ones?"* →
+`get_projects_for_review` with `includeOnHold: true`.
+
+**Expect:** normal output (may include more projects than TC4); no warning section.
+
+- [ ] **PASS** — normal output, no warning section
+- [ ] **FAIL** — warning section present or broken output
+
+---
+
+## TC6 — (Optional / informational) The warning path
+
+You are **not expected to be able to trigger this** on a healthy database — it
+fires only when reading a project's `flattenedTasks`, `parentFolder`,
+`nextReviewDate`, `folder`, or `reviewInterval` actually throws (corrupted or
+unusual database state). Do **not** treat a non-appearance as a failure.
+
+**If a warning ever does appear**, it will look exactly like this (wording/format
+to recognize):
+
+```
+⚠️ **Processing Warnings**:
+- 2 details could not be read; affected fields may show as '-', 0, or null
+- Samples: taskCount(Some Project): <error>; folder(Other Project): <error>
+```
+
+If you see this in normal use, capture the full output and the sample messages —
+that's a genuine signal that some project's metadata couldn't be read (or, if it
+appears spuriously in a clearly-healthy DB, a bug in the instrumentation worth
+reporting).
+
+- [ ] Not triggered (expected on a healthy DB)
+- [ ] Triggered — captured output for follow-up
+
+---
+
+## Optional — server log check
+
+If you can view the MCP server's stderr/log output, a `log.warn` line
+(`listProjects returned processing errors` / `getProjectsForReview returned
+processing errors`) should appear **only** alongside a warning section — i.e.
+never, in a healthy database. Absence of these log lines in TC2–TC5 is the
+expected, correct result.
+
+---
+
+## Red flags (treat as FAIL)
+
+- A `⚠️ Processing Warnings` section appears in TC2–TC5 on a database you believe
+  is healthy → either real read failures or over-counting in the instrumentation.
+- Output structure changed vs. previous versions (missing table, IDs, counts,
+  review fields) → regression from this change.
+- `get_server_version` ≠ `1.30.10` → you tested the wrong build; redo Setup.
+
+---
+
+## Results
+
+| Test | Result | Notes |
+|------|--------|-------|
+| TC1 Version gate | ☐ PASS ☐ FAIL | |
+| TC2 list_projects happy path | ☐ PASS ☐ FAIL | |
+| TC3 list_projects filters | ☐ PASS ☐ FAIL | |
+| TC4 get_projects_for_review happy path | ☐ PASS ☐ FAIL | |
+| TC5 get_projects_for_review on-hold | ☐ PASS ☐ FAIL | |
+| TC6 warning path (optional) | ☐ n/a ☐ triggered | |
+
+**Overall:** ☐ PASS (TC1–TC5 all pass) ☐ FAIL
+
+---
+
+## Notes — what's already been verified without OmniFocus
+
+- `npm run build` compiles cleanly; `node --check` passes on both OmniJS scripts.
+- The warning **render** path is verified directly against the compiled
+  `formatProcessingWarnings()`:
+  - a `{ metadataErrors, samples }` payload renders the warning above (plural/singular
+    grammar correct),
+  - a legacy `{ filterErrors, ... }` payload still renders the original "tasks
+    excluded" wording (no regression to the v1.30.7 filter-error behavior),
+  - `0` errors / `undefined` render an empty string (so the happy path shows no warning).
+
+The only unverified link is the OmniJS counting/attaching firing against a *real*
+OmniFocus read failure, which is what TC6 would exercise if it were triggerable.

--- a/docs/test-plans/issue-110-phase2-smoke-test.md
+++ b/docs/test-plans/issue-110-phase2-smoke-test.md
@@ -183,14 +183,16 @@ expected, correct result.
 
 | Test | Result | Notes |
 |------|--------|-------|
-| TC1 Version gate | ☐ PASS ☐ FAIL | |
-| TC2 list_projects happy path | ☐ PASS ☐ FAIL | |
-| TC3 list_projects filters | ☐ PASS ☐ FAIL | |
-| TC4 get_projects_for_review happy path | ☐ PASS ☐ FAIL | |
-| TC5 get_projects_for_review on-hold | ☐ PASS ☐ FAIL | |
-| TC6 warning path (optional) | ☐ n/a ☐ triggered | |
+| TC1 Version gate | ☑ PASS ☐ FAIL | `get_server_version` returned `1.30.10` |
+| TC2 list_projects happy path | ☑ PASS ☐ FAIL | Table + Project IDs + "Found **60** active projects:"; no warning section |
+| TC3 list_projects filters | ☑ PASS ☐ FAIL | `status:all` → 100, `folderName:<a folder>` → 12 (correctly scoped), `status:onHold` → 35; no warnings |
+| TC4 get_projects_for_review happy path | ☑ PASS ☐ FAIL | "(50 of 59)"; foldered projects now show `• Folder:` (cross-checked vs `list_projects`); a root-level project shows none; no warning section |
+| TC5 get_projects_for_review on-hold | ☑ PASS ☐ FAIL | "(50 of 94)"; on-hold projects included and showing folders (cross-checked vs `list_projects`); no warning section |
+| TC6 warning path (optional) | ☑ n/a ☐ triggered | No `⚠️ Processing Warnings` anywhere in TC2-TC5 (expected on a healthy DB) |
 
-**Overall:** ☐ PASS (TC1–TC5 all pass) ☐ FAIL
+**Overall:** ☑ PASS (TC1–TC5 all pass) ☐ FAIL
+
+**Run:** 2026-05-25 by Claude (Opus 4.7) in a Claude Code session, against the uncommitted working-tree build (v1.30.10), live OmniFocus database. Note: the issue #110 changes were still unstaged at time of test.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.30.9",
+  "version": "1.30.10",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/tools/definitions/getProjectsForReview.ts
+++ b/src/tools/definitions/getProjectsForReview.ts
@@ -3,6 +3,7 @@ import { getProjectsForReview, GetProjectsForReviewParams } from '../primitives/
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
 import { logger } from '../../utils/logger.js';
+import { formatProcessingWarnings } from '../../utils/formatUtils.js';
 
 const log = logger.child('def:getProjectsForReview');
 
@@ -54,6 +55,10 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
 
         infoText += '\n';
       }
+
+      // Surface any optional-field read failures (issue #110)
+      const warnings = formatProcessingWarnings(result.processingErrors);
+      if (warnings) infoText += `\n${warnings}`;
 
       return {
         content: [{

--- a/src/tools/definitions/listProjects.ts
+++ b/src/tools/definitions/listProjects.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { listProjects } from '../primitives/listProjects.js';
 import { formatDateSafe } from '../../utils/dateUtils.js';
+import { formatProcessingWarnings } from '../../utils/formatUtils.js';
 
 export const schema = z.object({
   folderName: z.string().optional().describe("Filter by folder name"),
@@ -67,6 +68,10 @@ export async function handler(
         output += `- ${project.name}: \`${project.id}\`\n`;
       }
     }
+
+    // Surface any optional-field read failures (issue #110)
+    const warnings = formatProcessingWarnings(result.processingErrors);
+    if (warnings) output += `\n${warnings}`;
 
     return {
       content: [{

--- a/src/tools/primitives/getProjectsForReview.ts
+++ b/src/tools/primitives/getProjectsForReview.ts
@@ -22,6 +22,11 @@ export interface ProjectForReview {
   lastReviewDate: string | null; // ISO date
 }
 
+export interface ProcessingErrors {
+  metadataErrors: number;
+  samples: string[];
+}
+
 /**
  * Get projects that need review from OmniFocus
  */
@@ -30,6 +35,7 @@ export async function getProjectsForReview(params: GetProjectsForReviewParams): 
   totalCount?: number;
   returnedCount?: number;
   projects?: ProjectForReview[];
+  processingErrors?: ProcessingErrors;
   error?: string;
 }> {
   try {
@@ -61,11 +67,15 @@ export async function getProjectsForReview(params: GetProjectsForReviewParams): 
     }
 
     if (parsed.success) {
+      if (parsed.processingErrors) {
+        log.warn('getProjectsForReview returned processing errors', parsed.processingErrors);
+      }
       return {
         success: true,
         totalCount: parsed.totalCount,
         returnedCount: parsed.returnedCount,
-        projects: parsed.projects as ProjectForReview[]
+        projects: parsed.projects as ProjectForReview[],
+        processingErrors: parsed.processingErrors
       };
     } else {
       return {

--- a/src/tools/primitives/listProjects.ts
+++ b/src/tools/primitives/listProjects.ts
@@ -21,12 +21,18 @@ interface ProjectInfo {
   nextReviewDate: string | null;
 }
 
+interface ProcessingErrors {
+  metadataErrors: number;
+  samples: string[];
+}
+
 interface ListProjectsResult {
   success: boolean;
   count: number;
   folderFilter: string | null;
   statusFilter: string;
   projects: ProjectInfo[];
+  processingErrors?: ProcessingErrors;
   error?: string;
 }
 
@@ -73,6 +79,10 @@ export async function listProjects(options: ListProjectsOptions = {}): Promise<L
       }
     } else {
       parsed = result as ListProjectsResult;
+    }
+
+    if (parsed.processingErrors) {
+      log.warn('listProjects returned processing errors', parsed.processingErrors);
     }
 
     return parsed;

--- a/src/utils/formatUtils.ts
+++ b/src/utils/formatUtils.ts
@@ -1,9 +1,14 @@
-// Format processing error warnings for display
+// Format processing error warnings for display.
+// Handles three error categories, any combination of which may be present:
+//   filterErrors / serializationErrors - tasks dropped during filter/serialize (issue #104/#109)
+//   metadataErrors                     - optional fields that could not be read; the item still
+//                                        appears but a field falls back to '-', 0, or null (issue #110)
 export function formatProcessingWarnings(processingErrors: any): string {
   if (!processingErrors) return '';
   const filterErrors = processingErrors.filterErrors || 0;
   const serializationErrors = processingErrors.serializationErrors || 0;
-  const totalErrors = filterErrors + serializationErrors;
+  const metadataErrors = processingErrors.metadataErrors || 0;
+  const totalErrors = filterErrors + serializationErrors + metadataErrors;
   if (totalErrors === 0) return '';
 
   let output = `⚠️ **Processing Warnings**:\n`;
@@ -12,6 +17,9 @@ export function formatProcessingWarnings(processingErrors: any): string {
   }
   if (serializationErrors > 0) {
     output += `- ${serializationErrors} task${serializationErrors === 1 ? '' : 's'} excluded due to serialization errors\n`;
+  }
+  if (metadataErrors > 0) {
+    output += `- ${metadataErrors} detail${metadataErrors === 1 ? '' : 's'} could not be read; affected fields may show as '-', 0, or null\n`;
   }
   if (processingErrors.samples && processingErrors.samples.length > 0) {
     output += `- Samples: ${processingErrors.samples.join('; ')}\n`;

--- a/src/utils/omnifocusScripts/getProjectsForReview.js
+++ b/src/utils/omnifocusScripts/getProjectsForReview.js
@@ -7,6 +7,11 @@
 
     const now = new Date();
 
+    // Track optional-field read failures instead of swallowing them silently (issue #110)
+    const MAX_ERROR_SAMPLES = 3;
+    let metadataErrorCount = 0;
+    const errorSamples = [];
+
     // Get project status string
     const statusMap = {
       [Project.Status.Active]: "Active",
@@ -31,7 +36,10 @@
           }
           folder = folder.parent; // Check parent folders too
         }
-      } catch (e) {}
+      } catch (e) {
+        // Intentionally not counted: defensive guard that returns a safe `false`
+        // on folder-traversal failure rather than dropping data (issue #110)
+      }
       return false;
     }
 
@@ -68,12 +76,16 @@
       let folderId = null;
       let folderName = null;
       try {
-        if (project.folder) {
-          folderId = project.folder.id.primaryKey;
-          folderName = project.folder.name;
+        // Use parentFolder, not folder (project.folder is always undefined; issue #110)
+        if (project.parentFolder) {
+          folderId = project.parentFolder.id.primaryKey;
+          folderName = project.parentFolder.name;
         }
       } catch (e) {
-        // Folder not accessible
+        metadataErrorCount++;
+        if (errorSamples.length < MAX_ERROR_SAMPLES) {
+          errorSamples.push(`folder(${project.name || 'unknown'}): ${e.message || String(e)}`);
+        }
       }
 
       let remainingTaskCount = 0;
@@ -84,7 +96,10 @@
           ).length;
         }
       } catch (e) {
-        // Task count not accessible
+        metadataErrorCount++;
+        if (errorSamples.length < MAX_ERROR_SAMPLES) {
+          errorSamples.push(`taskCount(${project.name || 'unknown'}): ${e.message || String(e)}`);
+        }
       }
 
       // Get review interval - ReviewInterval has .steps and .unit properties
@@ -100,7 +115,12 @@
           else if (unit === 'years') reviewIntervalSeconds = steps * 365 * 24 * 60 * 60;
           else reviewIntervalSeconds = steps;
         }
-      } catch (e) {}
+      } catch (e) {
+        metadataErrorCount++;
+        if (errorSamples.length < MAX_ERROR_SAMPLES) {
+          errorSamples.push(`reviewInterval(${project.name || 'unknown'}): ${e.message || String(e)}`);
+        }
+      }
 
       return {
         id: project.id.primaryKey,
@@ -115,12 +135,16 @@
       };
     });
 
-    return JSON.stringify({
+    const result = {
       success: true,
       totalCount: projectsNeedingReview.length,
       returnedCount: projects.length,
       projects: projects
-    });
+    };
+    if (metadataErrorCount > 0) {
+      result.processingErrors = { metadataErrors: metadataErrorCount, samples: errorSamples };
+    }
+    return JSON.stringify(result);
 
   } catch (error) {
     return JSON.stringify({

--- a/src/utils/omnifocusScripts/listProjects.js
+++ b/src/utils/omnifocusScripts/listProjects.js
@@ -8,6 +8,11 @@
     const includeDroppedFolders = args.includeDroppedFolders || false;
     const limit = args.limit || 100;
 
+    // Track optional-field read failures instead of swallowing them silently (issue #110)
+    const MAX_ERROR_SAMPLES = 3;
+    let metadataErrorCount = 0;
+    const errorSamples = [];
+
     // Status mapping
     const statusMap = {
       [Project.Status.Active]: "Active",
@@ -26,7 +31,10 @@
           }
           folder = folder.parent;
         }
-      } catch (e) {}
+      } catch (e) {
+        // Intentionally not counted: defensive guard that returns a safe `false`
+        // on folder-traversal failure rather than dropping data (issue #110)
+      }
       return false;
     }
 
@@ -109,7 +117,12 @@
             t => t.taskStatus !== Task.Status.Completed && t.taskStatus !== Task.Status.Dropped
           ).length;
         }
-      } catch (e) {}
+      } catch (e) {
+        metadataErrorCount++;
+        if (errorSamples.length < MAX_ERROR_SAMPLES) {
+          errorSamples.push(`taskCount(${project.name || 'unknown'}): ${e.message || String(e)}`);
+        }
+      }
 
       // Get folder info
       let projectFolderId = null;
@@ -119,7 +132,12 @@
           projectFolderId = project.parentFolder.id.primaryKey;
           projectFolderName = project.parentFolder.name;
         }
-      } catch (e) {}
+      } catch (e) {
+        metadataErrorCount++;
+        if (errorSamples.length < MAX_ERROR_SAMPLES) {
+          errorSamples.push(`folder(${project.name || 'unknown'}): ${e.message || String(e)}`);
+        }
+      }
 
       // Get review date
       let nextReviewDate = null;
@@ -127,7 +145,12 @@
         if (project.nextReviewDate) {
           nextReviewDate = project.nextReviewDate.toISOString();
         }
-      } catch (e) {}
+      } catch (e) {
+        metadataErrorCount++;
+        if (errorSamples.length < MAX_ERROR_SAMPLES) {
+          errorSamples.push(`reviewDate(${project.name || 'unknown'}): ${e.message || String(e)}`);
+        }
+      }
 
       filteredProjects.push({
         id: project.id.primaryKey,
@@ -148,13 +171,17 @@
     // Sort by name
     filteredProjects.sort((a, b) => a.name.localeCompare(b.name));
 
-    return JSON.stringify({
+    const result = {
       success: true,
       count: filteredProjects.length,
       folderFilter: folderName || folderId || null,
       statusFilter: statusFilter,
       projects: filteredProjects
-    });
+    };
+    if (metadataErrorCount > 0) {
+      result.processingErrors = { metadataErrors: metadataErrorCount, samples: errorSamples };
+    }
+    return JSON.stringify(result);
 
   } catch (error) {
     return JSON.stringify({


### PR DESCRIPTION
## Summary

Phase 2 of #110. `list_projects` and `get_projects_for_review` previously used empty `} catch (e) {}` blocks around optional-field reads, so when a project's **task count**, **folder**, or **review date/interval** couldn't be read, the field silently fell back to `0`/`null` — a partial result was indistinguishable from a complete one.

Both scripts now **count** such failures, capture up to 3 labeled sample messages, and attach `processingErrors: { metadataErrors, samples }` to their JSON. The TS layer renders a `⚠️ Processing Warnings` section and emits a `log.warn`. **Error-free calls are unchanged.**

## Also fixed: a latent folder bug (found during testing)

`get_projects_for_review` read `project.folder` — a property that's **always `undefined`** — instead of `project.parentFolder`, so its per-project folder line was *always* blank. This is a *non-throwing* wrong-property bug, so the error-surfacing above can't catch it (no exception is raised). The same file already had a `// Note: Use parentFolder property, not folder` comment that line 79 didn't follow. `list_projects` was never affected (it already used `parentFolder`).

## Design notes

- **Generalized, backward-compatible warning helper.** `formatProcessingWarnings()` gained a `metadataErrors` category alongside the existing `filterErrors`/`serializationErrors` (issue #104/#109). A legacy filter-error payload renders exactly as before.
- **The `processingErrors: { metadataErrors, samples }` contract is the template for the remaining #110 phases** (`getProjectByName.js`, `getFolderByName.js`, `getTaskByIdOrName.js`, `editItem.js`) — so the next PRs are mechanical.
- **Defensive guards left uncounted.** `isInDroppedFolder`/`isEffectivelyDropped` return a safe `false` on folder-traversal failure by design; counting them would double-count (`isInDroppedFolder` runs twice per project). Commented as intentional.
- **The review primitive reconstructs its result object** (whitelisting fields) rather than passing the script JSON through, so `processingErrors` is now explicitly forwarded — easy to miss.

## Verification

- `npm run build` clean; `node --check` passes on both OmniJS scripts.
- The render path is exercised directly against compiled `formatProcessingWarnings`: `metadataErrors` payload renders correctly (plural/singular grammar), a legacy `filterErrors` payload is unchanged, and `0`/`undefined` render empty (happy path → no warning).
- **Manual smoke test against OmniFocus passed** (`docs/test-plans/issue-110-phase2-smoke-test.md`): TC1–TC5 PASS — including the folder fix verified live with cross-checks against `list_projects` (folder values cross-checked against `list_projects` for active and on-hold projects); TC6 (warning path) not triggerable on a healthy database, as expected.

## Scope

Phase 2 only (`listProjects.js`, `getProjectsForReview.js`). #110 stays open for Phases 3–4. Version bumped to 1.30.10; `docs/WHATS_NEW.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
