### PR TITLE
fix(#110): Phase 3 — entity-lookup error surfacing + parent guard fixes

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,23 @@
-# OmniFocus MCP Server - What's New (v1.30.10)
+# OmniFocus MCP Server - What's New (v1.30.11)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.30.11 Fix parent lookups + surface metadata read errors in entity-lookup tools (Issue #110, Phase 3)
+
+**Two parent-field fixes (most user-visible).** Both were wrong-property guards that tested a sub-property which does not exist, so the guarded body never ran and the field was *always* null — invisible to error-handling because nothing ever threw:
+
+- **`get_folder_by_id`** now populates `parentFolderName` / `parentFolderId` (and shows a `• Parent Folder:` line) when a folder is nested inside another folder. The guard previously checked a non-existent `folder.parent.folder`. Top-level folders correctly still show no parent.
+- **`get_task_by_id`** now populates `parentName` / `parentId` (and shows a `• Parent Task:` line) for a **genuine subtask** (a task nested under another task). The guard previously checked a non-existent `task.parent.task`. Top-level tasks correctly still show *no* parent (their `parent` is the project's hidden root task, which is excluded via `task.parent.project`) and continue to show their `• Project:` line as before.
+
+**Error-surfacing for the three entity-lookup tools.** `get_project_by_id`, `get_folder_by_id`, and `get_task_by_id` no longer silently swallow optional-field read errors. Previously, if a project's task count / folder / review dates, a folder's project or subfolder counts, or a task's parent / project / tags couldn't be read, the `catch` block discarded the error and the field silently fell back to `0`/`null`. These tools now count such failures and append a **⚠️ Processing Warnings** section (up to 3 sample messages) and emit a server-side `log.warn`.
+
+**Impact:** Error-free calls produce identical output to before — the warning only appears when a field actually failed to read. The entity itself is still returned; this only adds visibility into incomplete data.
+
+**Cache caveat (`get_task_by_id` only):** this tool caches its result, so if a lookup ever does produce a warning, the warning re-surfaces on subsequent cache hits for the same task until the cache entry expires.
+
+**Pattern.** This reuses the `processingErrors: { metadataErrors, samples }` contract from v1.30.10 (Phase 2), rendered by the shared `formatProcessingWarnings()`. The shared `ProcessingErrors` type now lives in `src/utils/formatUtils.ts`. Defensive folder-traversal guards that return a safe default (`getEffectiveStatus`) remain intentionally uncounted. Remaining: Phase 4 = `editItem.js`.
+
+---
 
 ## v1.30.10 Surface metadata read errors in project listing tools (Issue #110, Phase 2)
 

--- a/docs/test-plans/issue-110-phase3-smoke-test.md
+++ b/docs/test-plans/issue-110-phase3-smoke-test.md
@@ -188,16 +188,16 @@ database. Absence of these log lines in TC2–TC5 is the expected, correct resul
 
 | Test | Result | Notes |
 |------|--------|-------|
-| TC1 Version gate | ☐ PASS ☐ FAIL | |
-| TC2 get_project_by_id happy path | ☐ PASS ☐ FAIL | |
-| TC3 get_folder_by_id parent fix | ☐ PASS ☐ FAIL | |
-| TC4 get_task_by_id parent fix + guard | ☐ PASS ☐ FAIL | |
-| TC5 regression sweep | ☐ PASS ☐ FAIL | |
-| TC6 warning path (optional) | ☐ n/a ☐ triggered | |
+| TC1 Version gate | ☑ PASS ☐ FAIL | `get_server_version` → `1.30.11` (branch `claude/refine-local-plan-Zzg2b` @ `3b34cc9`) |
+| TC2 get_project_by_id happy path | ☑ PASS ☐ FAIL | Foldered project, 10 tasks: full Project + Review block, no warning section |
+| TC3 get_folder_by_id parent fix | ☑ PASS ☐ FAIL | Nested folder shows `Parent Folder: <name>`; top-level folder (8 subfolders) shows none; no warnings. Parent subfolder-count and child parent-name agree both directions |
+| TC4 get_task_by_id parent fix + guard | ☑ PASS ☐ FAIL | Subtask shows `Parent Task` + `Project` (verified two levels deep); top-level task shows `Project` and NO `Parent Task`. Guard confirmed on synthetic `test-project` and a real foldered project |
+| TC5 regression sweep | ☑ PASS ☐ FAIL | ~16 lookups across all three tools (projects ±folder, nested + top-level folders, subtask + top-level tasks); zero `Processing Warnings` sections |
+| TC6 warning path (optional) | ☑ n/a ☐ triggered | Not triggered (expected on healthy DB); render path covered by the automated check |
 
-**Overall:** ☐ PASS (TC1–TC5 all pass) ☐ FAIL
+**Overall:** ☑ PASS (TC1–TC5 all pass) ☐ FAIL
 
-**Run:** _(fill in date / tester / build under test)_
+**Run:** 2026-05-25 / MoJen (Claude Code session) / branch `claude/refine-local-plan-Zzg2b` @ `3b34cc9`, server v1.30.11 (entity names sanitised)
 
 ---
 

--- a/docs/test-plans/issue-110-phase3-smoke-test.md
+++ b/docs/test-plans/issue-110-phase3-smoke-test.md
@@ -1,0 +1,213 @@
+# Smoke Test — Issue #110 Phase 3 (entity-lookup error surfacing)
+
+**Branch:** `claude/refine-local-plan-Zzg2b`
+**Version under test:** `1.30.11`
+**Tools affected:** `get_project_by_id`, `get_folder_by_id`, `get_task_by_id`
+**Run in:** a Claude Code (or other MCP client) session connected to **OmniFocus** on macOS.
+
+---
+
+## What changed (context for the tester)
+
+These three lookup tools used to swallow errors when an optional field couldn't be
+read (`} catch (e) {}`). A project's task count / folder / review dates, a folder's
+project/subfolder counts, or a task's parent / project / tags would silently fall
+back to `0`/`null`, so a partial result looked identical to a complete one.
+
+Now, when such a read fails, the tool **counts** it, captures up to 3 sample
+messages, and appends a `⚠️ Processing Warnings` section to its output (and emits a
+server-side `log.warn`). **The entity is still returned** — this only adds
+*visibility* into incomplete data.
+
+The central thing this smoke test confirms is the **regression case**: in a healthy
+database, *nothing fails to read*, so the output must be **identical to before — no
+warning section at all.** The warning path itself is exotic and not expected to
+trigger on a normal database (its rendering is already verified by an automated
+check — see "Notes").
+
+**Also bundled (v1.30.11) — two parent-field fixes that change output:**
+
+- **`get_folder_by_id`** previously checked a non-existent `folder.parent.folder`, so
+  a nested folder's parent was *always* blank. It now shows `• Parent Folder: <name>`
+  for foldered folders (TC3). Top-level folders correctly still show none.
+- **`get_task_by_id`** previously checked a non-existent `task.parent.task`, so a
+  subtask's parent was *always* blank. It now shows `• Parent Task: <name> (<id>)`
+  for a genuine subtask (TC4). A **top-level task** correctly still shows *no* parent
+  (its `parent` is the project's hidden root task, excluded via `task.parent.project`)
+  — that exclusion is the regression check in TC4.
+
+These were wrong-property bugs, not swallowed exceptions, so the error-surfacing
+above does not catch them — TC3/TC4 verify the parents now appear.
+
+---
+
+## Setup (do this once before the test cases)
+
+1. **Build this branch** so the MCP server runs v1.30.11:
+   ```bash
+   cd /Users/mojen/dev/of-mcp
+   git checkout claude/refine-local-plan-Zzg2b
+   npm install   # if needed
+   npm run build
+   ```
+2. **Point your MCP client at this build** (`dist/server.js` in this repo) and
+   **restart the session** so it loads the new build.
+3. Have OmniFocus running with your normal database (or any database that has at
+   least a few projects, ideally at least one **nested folder** and at least one
+   **subtask** so TC3/TC4 are exercisable).
+
+---
+
+## TC1 — Version gate (must pass before anything else)
+
+**Why:** confirms you're testing this branch's build, not an older one.
+
+**Do:** ask Claude to run the `get_server_version` tool.
+
+**Expect:** the returned JSON has `"version": "1.30.11"`.
+
+- [ ] **PASS** — version is `1.30.11`
+- [ ] **FAIL** — any other version (stop; you're testing the wrong build — revisit Setup)
+
+---
+
+## TC2 — `get_project_by_id` happy path (primary regression check)
+
+**Do:** look up a real project by name or ID → `get_project_by_id`.
+
+**Expect:**
+- A normal `📁 **Project Information**` block (Name, ID, Status, Folder if any,
+  Tasks, Sequential, Flagged, dates, review info where present).
+- **No `⚠️ Processing Warnings` section anywhere in the output.**
+
+- [ ] **PASS** — normal output, fields populated, no warning section
+- [ ] **FAIL** — warning section present, OR fields missing/malformed (record the output)
+
+---
+
+## TC3 — `get_folder_by_id` parent-folder fix (output changes)
+
+**Do:**
+1. Look up a **nested folder** (a folder that lives inside another folder) →
+   `get_folder_by_id`.
+2. Look up a **top-level folder** (directly under the library) → `get_folder_by_id`.
+
+**Expect:**
+- The nested folder now shows a `• **Parent Folder**: <name>` line (this line never
+  appeared before v1.30.11 for *any* folder).
+- The top-level folder shows **no** Parent Folder line.
+- Both show normal `📂 Folder Information` (Projects, Subfolders counts); **no warning
+  section** in either.
+
+- [ ] **PASS** — nested folder shows parent; top-level shows none; no warnings
+- [ ] **FAIL** — parent missing for a known-nested folder, parent shown for a top-level folder, or a warning appears (record output)
+
+---
+
+## TC4 — `get_task_by_id` parent-task fix + regression guard (output changes)
+
+**Do:**
+1. Look up a **genuine subtask** (a task nested *under another task*) →
+   `get_task_by_id`.
+2. Look up a **top-level task** (a direct action of a project, *not* nested under
+   another task) → `get_task_by_id`.
+
+**Expect:**
+- The subtask now shows a `• **Parent Task**: <name> (<id>)` line (this line never
+  appeared before v1.30.11), **and** still shows its `• **Project**:` line.
+- The top-level task shows **no** Parent Task line (its parent is the project's
+  hidden root task, deliberately excluded) but **does** still show `• **Project**:`.
+  This is the regression check for the `!task.parent.project` guard — if a top-level
+  task suddenly shows a "Parent Task" equal to its project name, that is a FAIL.
+- **No warning section** in either.
+
+- [ ] **PASS** — subtask shows parent; top-level shows none but shows Project; no warnings
+- [ ] **FAIL** — parent missing for a known subtask, OR a top-level task shows a (root-task) parent, OR a warning appears (record output)
+
+---
+
+## TC5 — Regression sweep (the core guarantee)
+
+**Do:** run a handful of normal lookups across all three tools — a few projects, a
+few folders (nested and top-level), a few tasks (subtasks and top-level).
+
+**Expect:** every call returns normal output with correct fields and **no
+`⚠️ Processing Warnings` section anywhere** on a healthy database.
+
+- [ ] **PASS** — all normal, no warnings anywhere
+- [ ] **FAIL** — any warning section on a healthy DB, or broken/missing fields (note which)
+
+---
+
+## TC6 — (Optional / informational) The warning path
+
+You are **not expected to be able to trigger this** on a healthy database — it fires
+only when reading an optional field (e.g. a project's `flattenedTasks`/`parentFolder`/
+review dates, a folder's `projects`/`folders`/`parent`, or a task's `parent`/
+`containingProject`/`tags`) actually throws (corrupted or unusual database state). Do
+**not** treat a non-appearance as a failure.
+
+**If a warning ever does appear**, it will look exactly like this:
+
+```
+⚠️ **Processing Warnings**:
+- 2 details could not be read; affected fields may show as '-', 0, or null
+- Samples: taskCount(Some Project): <error>; folder(Some Project): <error>
+```
+
+**`get_task_by_id` cache caveat:** this tool caches its result. If a task lookup ever
+produces a warning, the warning will re-appear on subsequent lookups of the *same*
+task until the cache entry expires — even if the underlying read would now succeed.
+
+- [ ] Not triggered (expected on a healthy DB)
+- [ ] Triggered — captured output for follow-up
+
+---
+
+## Optional — server log check
+
+If you can view the MCP server's stderr/log output, a `log.warn` line
+(`getProjectById` / `getFolderById` / `getTaskById returned processing errors`)
+should appear **only** alongside a warning section — i.e. never, in a healthy
+database. Absence of these log lines in TC2–TC5 is the expected, correct result.
+
+---
+
+## Red flags (treat as FAIL)
+
+- A `⚠️ Processing Warnings` section appears in TC2–TC5 on a database you believe is
+  healthy → either real read failures or over-counting in the instrumentation.
+- A top-level task shows a `• Parent Task:` line (named like its project) → the
+  `!task.parent.project` guard regressed.
+- Output structure otherwise changed vs. previous versions → regression.
+- `get_server_version` ≠ `1.30.11` → you tested the wrong build; redo Setup.
+
+---
+
+## Results
+
+| Test | Result | Notes |
+|------|--------|-------|
+| TC1 Version gate | ☐ PASS ☐ FAIL | |
+| TC2 get_project_by_id happy path | ☐ PASS ☐ FAIL | |
+| TC3 get_folder_by_id parent fix | ☐ PASS ☐ FAIL | |
+| TC4 get_task_by_id parent fix + guard | ☐ PASS ☐ FAIL | |
+| TC5 regression sweep | ☐ PASS ☐ FAIL | |
+| TC6 warning path (optional) | ☐ n/a ☐ triggered | |
+
+**Overall:** ☐ PASS (TC1–TC5 all pass) ☐ FAIL
+
+**Run:** _(fill in date / tester / build under test)_
+
+---
+
+## Notes — what's already been verified without OmniFocus
+
+- `npm run build` compiles cleanly; `node --check` passes on all three OmniJS scripts.
+- The warning **render** path is unchanged from Phase 2 and already verified against
+  the compiled `formatProcessingWarnings()`: a `{ metadataErrors, samples }` payload
+  renders the warning above; `0` / `undefined` renders an empty string (so the happy
+  path shows no warning).
+
+The only unverified link is the OmniJS counting/attaching firing against a *real*
+OmniFocus read failure, which is what TC6 would exercise if it were triggerable.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.30.10",
+  "version": "1.30.11",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/tools/definitions/getFolderById.ts
+++ b/src/tools/definitions/getFolderById.ts
@@ -3,6 +3,7 @@ import { getFolderById, GetFolderByIdParams } from '../primitives/getFolderById.
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
 import { logger } from '../../utils/logger.js';
+import { formatProcessingWarnings } from '../../utils/formatUtils.js';
 
 const log = logger.child('def:getFolderById');
 
@@ -42,6 +43,10 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
 
       infoText += `• **Projects**: ${folder.activeProjectCount} active (${folder.projectCount} total)\n`;
       infoText += `• **Subfolders**: ${folder.subfolderCount}\n`;
+
+      // Surface any optional-field read failures (issue #110)
+      const warnings = formatProcessingWarnings(result.processingErrors);
+      if (warnings) infoText += `\n${warnings}`;
 
       return {
         content: [{

--- a/src/tools/definitions/getProjectById.ts
+++ b/src/tools/definitions/getProjectById.ts
@@ -3,6 +3,7 @@ import { getProjectById, GetProjectByIdParams } from '../primitives/getProjectBy
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
 import { logger } from '../../utils/logger.js';
+import { formatProcessingWarnings } from '../../utils/formatUtils.js';
 
 const log = logger.child('def:getProjectById');
 
@@ -74,6 +75,10 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
           infoText += `• **Last Reviewed**: ${project.lastReviewDate}\n`;
         }
       }
+
+      // Surface any optional-field read failures (issue #110)
+      const warnings = formatProcessingWarnings(result.processingErrors);
+      if (warnings) infoText += `\n${warnings}`;
 
       return {
         content: [{

--- a/src/tools/definitions/getTaskById.ts
+++ b/src/tools/definitions/getTaskById.ts
@@ -4,6 +4,7 @@ import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.j
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
 import { formatDateSafe } from '../../utils/dateUtils.js';
 import { logger } from '../../utils/logger.js';
+import { formatProcessingWarnings } from '../../utils/formatUtils.js';
 
 const log = logger.child('def:getTaskById');
 
@@ -73,6 +74,10 @@ export async function handler(args: z.infer<typeof schema>, _extra: RequestHandl
       if (task.isRepeating && task.repetitionRule) {
         infoText += `• **Repeats**: ${task.repetitionRule}\n`;
       }
+
+      // Surface any optional-field read failures (issue #110)
+      const warnings = formatProcessingWarnings(result.processingErrors);
+      if (warnings) infoText += `\n${warnings}`;
 
       return {
         content: [{

--- a/src/tools/primitives/getFolderById.ts
+++ b/src/tools/primitives/getFolderById.ts
@@ -1,5 +1,6 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
 import { logger } from '../../utils/logger.js';
+import { ProcessingErrors } from '../../utils/formatUtils.js';
 
 const log = logger.child('getFolderById');
 
@@ -24,7 +25,7 @@ export interface FolderInfo {
 /**
  * Get folder information by ID or name from OmniFocus
  */
-export async function getFolderById(params: GetFolderByIdParams): Promise<{success: boolean, folder?: FolderInfo, error?: string}> {
+export async function getFolderById(params: GetFolderByIdParams): Promise<{success: boolean, folder?: FolderInfo, processingErrors?: ProcessingErrors, error?: string}> {
   try {
     // Validate parameters
     if (!params.folderId && !params.folderName) {
@@ -62,9 +63,13 @@ export async function getFolderById(params: GetFolderByIdParams): Promise<{succe
     }
 
     if (parsed.success) {
+      if (parsed.processingErrors) {
+        log.warn('getFolderById returned processing errors', parsed.processingErrors);
+      }
       return {
         success: true,
-        folder: parsed.folder as FolderInfo
+        folder: parsed.folder as FolderInfo,
+        processingErrors: parsed.processingErrors
       };
     } else {
       return {

--- a/src/tools/primitives/getProjectById.ts
+++ b/src/tools/primitives/getProjectById.ts
@@ -1,5 +1,6 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
 import { logger } from '../../utils/logger.js';
+import { ProcessingErrors } from '../../utils/formatUtils.js';
 
 const log = logger.child('getProjectById');
 
@@ -35,7 +36,7 @@ export interface ProjectInfo {
 /**
  * Get project information by ID or name from OmniFocus
  */
-export async function getProjectById(params: GetProjectByIdParams): Promise<{success: boolean, project?: ProjectInfo, error?: string}> {
+export async function getProjectById(params: GetProjectByIdParams): Promise<{success: boolean, project?: ProjectInfo, processingErrors?: ProcessingErrors, error?: string}> {
   try {
     // Validate parameters
     if (!params.projectId && !params.projectName) {
@@ -73,9 +74,13 @@ export async function getProjectById(params: GetProjectByIdParams): Promise<{suc
     }
 
     if (parsed.success) {
+      if (parsed.processingErrors) {
+        log.warn('getProjectById returned processing errors', parsed.processingErrors);
+      }
       return {
         success: true,
-        project: parsed.project as ProjectInfo
+        project: parsed.project as ProjectInfo,
+        processingErrors: parsed.processingErrors
       };
     } else {
       return {

--- a/src/tools/primitives/getProjectsForReview.ts
+++ b/src/tools/primitives/getProjectsForReview.ts
@@ -1,5 +1,6 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
 import { logger } from '../../utils/logger.js';
+import { ProcessingErrors } from '../../utils/formatUtils.js';
 
 const log = logger.child('getProjectsForReview');
 
@@ -20,11 +21,6 @@ export interface ProjectForReview {
   reviewInterval: number | null; // seconds between reviews
   nextReviewDate: string | null; // ISO date
   lastReviewDate: string | null; // ISO date
-}
-
-export interface ProcessingErrors {
-  metadataErrors: number;
-  samples: string[];
 }
 
 /**

--- a/src/tools/primitives/getTaskById.ts
+++ b/src/tools/primitives/getTaskById.ts
@@ -1,6 +1,7 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
 import { queryCache } from '../../utils/cache.js';
 import { logger } from '../../utils/logger.js';
+import { ProcessingErrors } from '../../utils/formatUtils.js';
 
 const log = logger.child('getTaskById');
 
@@ -33,7 +34,7 @@ export interface TaskInfo {
  * Get task information by ID or name from OmniFocus
  * Uses OmniJS to avoid AppleScript escaping issues with special characters like $
  */
-export async function getTaskById(params: GetTaskByIdParams): Promise<{success: boolean, task?: TaskInfo, error?: string}> {
+export async function getTaskById(params: GetTaskByIdParams): Promise<{success: boolean, task?: TaskInfo, processingErrors?: ProcessingErrors, error?: string}> {
   try {
     // Validate parameters
     if (!params.taskId && !params.taskName) {
@@ -49,7 +50,7 @@ export async function getTaskById(params: GetTaskByIdParams): Promise<{success: 
     };
 
     // Check cache first (getWithChecksum returns checksum for race-condition-free set)
-    type CacheResult = {success: boolean, task?: TaskInfo, error?: string};
+    type CacheResult = {success: boolean, task?: TaskInfo, processingErrors?: ProcessingErrors, error?: string};
     const { data: cached, checksum } = await queryCache.getWithChecksum<CacheResult>('getTaskById', scriptParams);
     if (cached) {
       log.debug('Using cached result');
@@ -77,8 +78,12 @@ export async function getTaskById(params: GetTaskByIdParams): Promise<{success: 
       parsed = result;
     }
 
+    if (parsed.success && parsed.processingErrors) {
+      log.warn('getTaskById returned processing errors', parsed.processingErrors);
+    }
+
     const response: CacheResult = parsed.success
-      ? { success: true, task: parsed.task as TaskInfo }
+      ? { success: true, task: parsed.task as TaskInfo, processingErrors: parsed.processingErrors }
       : { success: false, error: parsed.error || "Unknown error" };
 
     // Cache the result with the same checksum used for validation

--- a/src/tools/primitives/listProjects.ts
+++ b/src/tools/primitives/listProjects.ts
@@ -1,5 +1,6 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
 import { logger } from '../../utils/logger.js';
+import { ProcessingErrors } from '../../utils/formatUtils.js';
 
 const log = logger.child('listProjects');
 
@@ -19,11 +20,6 @@ interface ProjectInfo {
   folderId: string | null;
   folderName: string | null;
   nextReviewDate: string | null;
-}
-
-interface ProcessingErrors {
-  metadataErrors: number;
-  samples: string[];
 }
 
 interface ListProjectsResult {

--- a/src/utils/formatUtils.ts
+++ b/src/utils/formatUtils.ts
@@ -3,6 +3,12 @@
 //   filterErrors / serializationErrors - tasks dropped during filter/serialize (issue #104/#109)
 //   metadataErrors                     - optional fields that could not be read; the item still
 //                                        appears but a field falls back to '-', 0, or null (issue #110)
+// Shape attached by OmniJS scripts that count optional-field read failures (issue #110).
+export interface ProcessingErrors {
+  metadataErrors: number;
+  samples: string[];
+}
+
 export function formatProcessingWarnings(processingErrors: any): string {
   if (!processingErrors) return '';
   const filterErrors = processingErrors.filterErrors || 0;

--- a/src/utils/omnifocusScripts/getFolderByName.js
+++ b/src/utils/omnifocusScripts/getFolderByName.js
@@ -5,6 +5,11 @@
     const folderId = args.folderId || null;
     const folderName = args.folderName || null;
 
+    // Track optional-field read failures instead of swallowing them silently (issue #110)
+    const MAX_ERROR_SAMPLES = 3;
+    let metadataErrorCount = 0;
+    const errorSamples = [];
+
     if (!folderId && !folderName) {
       return JSON.stringify({
         success: false,
@@ -71,7 +76,10 @@
         ).length;
       }
     } catch (e) {
-      // Project count not accessible
+      metadataErrorCount++;
+      if (errorSamples.length < MAX_ERROR_SAMPLES) {
+        errorSamples.push(`projectCount(${foundFolder.name || 'unknown'}): ${e.message || String(e)}`);
+      }
     }
 
     // Get subfolder count
@@ -80,23 +88,33 @@
         folderInfo.subfolderCount = foundFolder.folders.length;
       }
     } catch (e) {
-      // Subfolder count not accessible
+      metadataErrorCount++;
+      if (errorSamples.length < MAX_ERROR_SAMPLES) {
+        errorSamples.push(`subfolderCount(${foundFolder.name || 'unknown'}): ${e.message || String(e)}`);
+      }
     }
 
-    // Get parent folder info
+    // Get parent folder info (Folder.parent is itself a Folder, or null for top-level folders)
     try {
-      if (foundFolder.parent && foundFolder.parent.folder) {
+      if (foundFolder.parent) {
         folderInfo.parentFolderId = foundFolder.parent.id.primaryKey;
         folderInfo.parentFolderName = foundFolder.parent.name;
       }
     } catch (e) {
-      // Parent folder not accessible
+      metadataErrorCount++;
+      if (errorSamples.length < MAX_ERROR_SAMPLES) {
+        errorSamples.push(`parentFolder(${foundFolder.name || 'unknown'}): ${e.message || String(e)}`);
+      }
     }
 
-    return JSON.stringify({
+    const result = {
       success: true,
       folder: folderInfo
-    });
+    };
+    if (metadataErrorCount > 0) {
+      result.processingErrors = { metadataErrors: metadataErrorCount, samples: errorSamples };
+    }
+    return JSON.stringify(result);
 
   } catch (error) {
     return JSON.stringify({

--- a/src/utils/omnifocusScripts/getProjectByName.js
+++ b/src/utils/omnifocusScripts/getProjectByName.js
@@ -5,6 +5,11 @@
     const projectId = args.projectId || null;
     const projectName = args.projectName || null;
 
+    // Track optional-field read failures instead of swallowing them silently (issue #110)
+    const MAX_ERROR_SAMPLES = 3;
+    let metadataErrorCount = 0;
+    const errorSamples = [];
+
     if (!projectId && !projectName) {
       return JSON.stringify({
         success: false,
@@ -68,7 +73,10 @@
           }
           folder = folder.parent;
         }
-      } catch (e) {}
+      } catch (e) {
+        // Intentionally not counted: defensive guard that falls back to the
+        // project's own status on folder-traversal failure rather than failing (issue #110)
+      }
       // Return the project's own status
       return statusMap[project.status] || "Unknown";
     }
@@ -104,17 +112,35 @@
           else if (unit === 'months') seconds = steps * 30 * 24 * 60 * 60;
           else if (unit === 'years') seconds = steps * 365 * 24 * 60 * 60;
           return seconds;
-        } catch (e) { return null; }
+        } catch (e) {
+          metadataErrorCount++;
+          if (errorSamples.length < MAX_ERROR_SAMPLES) {
+            errorSamples.push(`reviewInterval(${foundProject.name || 'unknown'}): ${e.message || String(e)}`);
+          }
+          return null;
+        }
       })(),
       nextReviewDate: (function() {
         try {
           return foundProject.nextReviewDate ? foundProject.nextReviewDate.toISOString() : null;
-        } catch (e) { return null; }
+        } catch (e) {
+          metadataErrorCount++;
+          if (errorSamples.length < MAX_ERROR_SAMPLES) {
+            errorSamples.push(`nextReviewDate(${foundProject.name || 'unknown'}): ${e.message || String(e)}`);
+          }
+          return null;
+        }
       })(),
       lastReviewDate: (function() {
         try {
           return foundProject.lastReviewDate ? foundProject.lastReviewDate.toISOString() : null;
-        } catch (e) { return null; }
+        } catch (e) {
+          metadataErrorCount++;
+          if (errorSamples.length < MAX_ERROR_SAMPLES) {
+            errorSamples.push(`lastReviewDate(${foundProject.name || 'unknown'}): ${e.message || String(e)}`);
+          }
+          return null;
+        }
       })()
     };
 
@@ -127,7 +153,10 @@
         ).length;
       }
     } catch (e) {
-      // Task count not accessible
+      metadataErrorCount++;
+      if (errorSamples.length < MAX_ERROR_SAMPLES) {
+        errorSamples.push(`taskCount(${foundProject.name || 'unknown'}): ${e.message || String(e)}`);
+      }
     }
 
     // Get folder info (use parentFolder, not folder)
@@ -137,13 +166,20 @@
         projectInfo.folderName = foundProject.parentFolder.name;
       }
     } catch (e) {
-      // Folder not accessible
+      metadataErrorCount++;
+      if (errorSamples.length < MAX_ERROR_SAMPLES) {
+        errorSamples.push(`folder(${foundProject.name || 'unknown'}): ${e.message || String(e)}`);
+      }
     }
 
-    return JSON.stringify({
+    const result = {
       success: true,
       project: projectInfo
-    });
+    };
+    if (metadataErrorCount > 0) {
+      result.processingErrors = { metadataErrors: metadataErrorCount, samples: errorSamples };
+    }
+    return JSON.stringify(result);
 
   } catch (error) {
     return JSON.stringify({

--- a/src/utils/omnifocusScripts/getTaskByIdOrName.js
+++ b/src/utils/omnifocusScripts/getTaskByIdOrName.js
@@ -6,6 +6,11 @@
     const taskId = args.taskId || null;
     const taskName = args.taskName || null;
 
+    // Track optional-field read failures instead of swallowing them silently (issue #110)
+    const MAX_ERROR_SAMPLES = 3;
+    let metadataErrorCount = 0;
+    const errorSamples = [];
+
     if (!taskId && !taskName) {
       return JSON.stringify({
         success: false,
@@ -68,14 +73,18 @@
       isRepeating: foundTask.repetitionRule !== null
     };
 
-    // Get parent info
+    // Get parent info. A top-level task's parent is the project's root task
+    // (whose .project is truthy); only report a genuine subtask's parent here.
     try {
-      if (foundTask.parent && foundTask.parent.task) {
+      if (foundTask.parent && !foundTask.parent.project) {
         taskInfo.parentId = foundTask.parent.id.primaryKey;
         taskInfo.parentName = foundTask.parent.name;
       }
     } catch (e) {
-      // Parent not accessible
+      metadataErrorCount++;
+      if (errorSamples.length < MAX_ERROR_SAMPLES) {
+        errorSamples.push(`parent(${foundTask.name || 'unknown'}): ${e.message || String(e)}`);
+      }
     }
 
     // Get project info
@@ -85,7 +94,10 @@
         taskInfo.projectName = foundTask.containingProject.name;
       }
     } catch (e) {
-      // Project not accessible
+      metadataErrorCount++;
+      if (errorSamples.length < MAX_ERROR_SAMPLES) {
+        errorSamples.push(`project(${foundTask.name || 'unknown'}): ${e.message || String(e)}`);
+      }
     }
 
     // Get tags
@@ -97,13 +109,20 @@
         }));
       }
     } catch (e) {
-      // Tags not accessible
+      metadataErrorCount++;
+      if (errorSamples.length < MAX_ERROR_SAMPLES) {
+        errorSamples.push(`tags(${foundTask.name || 'unknown'}): ${e.message || String(e)}`);
+      }
     }
 
-    return JSON.stringify({
+    const result = {
       success: true,
       task: taskInfo
-    });
+    };
+    if (metadataErrorCount > 0) {
+      result.processingErrors = { metadataErrors: metadataErrorCount, samples: errorSamples };
+    }
+    return JSON.stringify(result);
 
   } catch (error) {
     return JSON.stringify({


### PR DESCRIPTION
## Summary

Issue #110 Phase 3. Applies the Phase 2 (PR #121) count-and-sample `processingErrors` pattern to the three entity-lookup tools — `get_project_by_id`, `get_folder_by_id`, `get_task_by_id` — so partial optional-field reads surface a `⚠️ Processing Warnings` section instead of being swallowed by empty `catch` blocks. **A healthy database produces identical output to today** — the warning only appears when a field actually fails to read.

Also bundles two confirmed wrong-property guard fixes (same class as the Phase 2 `project.folder`→`parentFolder` bug — a guard tested a sub-property that doesn't exist, so the body never ran and the field was *always* null, invisible to error-handling because nothing threw):

- **`get_folder_by_id`** checked a non-existent `folder.parent.folder` → now `if (foundFolder.parent)`, so a **nested folder** populates `parentFolderName`/`parentFolderId` (shows `• Parent Folder:`). Top-level folders correctly still show none.
- **`get_task_by_id`** checked a non-existent `task.parent.task` → now `if (foundTask.parent && !foundTask.parent.project)`, so a **genuine subtask** populates `parentName`/`parentId` (shows `• Parent Task:`). A top-level task's `.parent` is the project's hidden root task (`.project` truthy), which is excluded — so top-level tasks correctly stay null, exactly as today. (Repo evidence for this: `duplicateProject.js` seeds tree recursion with `rootTask.id` and matches `task.parent.id`; `systemHealth.js` comments `!task.project` as "exclude project root tasks". The naive `if (foundTask.parent)` would have shown every top-level task's project root as its parent — a regression.)

Shared `ProcessingErrors` type consolidated into `src/utils/formatUtils.ts` (the two Phase-2 duplicates removed). `formatProcessingWarnings()` is unchanged.

## Changes
- OmniJS: `getProjectByName.js` (5 counted catches incl. 3 review IIFEs; 1 defensive catch left uncounted with comment), `getFolderByName.js` (3 + guard fix), `getTaskByIdOrName.js` (3 + corrected guard fix)
- TS primitives forward `processingErrors` + `log.warn`; `getTaskById` cache type/response updated so warnings survive cache hits (caveat: a with-warnings result is "sticky" on cache hits until TTL)
- TS definitions render via `formatProcessingWarnings`
- `package.json` → 1.30.11; `docs/WHATS_NEW.md` entry; new `docs/test-plans/issue-110-phase3-smoke-test.md`

## Test plan
- [x] `tsc --noEmit` clean (TS 5.6.3 — see `TSC_OOM_TROUBLESHOOTING.md`; 5.8+ hangs on this repo)
- [x] esbuild bundle builds; all three OmniJS scripts pass `node --check` in `src/` and `dist/`
- [ ] **Live smoke test against OmniFocus** (`docs/test-plans/issue-110-phase3-smoke-test.md`):
  - TC1 version gate (`1.30.11`)
  - TC2 `get_project_by_id` happy path — no warning section
  - TC3 `get_folder_by_id` — nested folder now shows `• Parent Folder:`; top-level shows none (output change)
  - TC4 `get_task_by_id` — subtask now shows `• Parent Task:`; top-level shows none but still shows `• Project:` (output change + regression guard)
  - TC5 regression sweep — no `⚠️ Processing Warnings` anywhere on a healthy DB
  - TC6 (optional) warning path — not expected to trigger

Closes part of #110 (Phase 3 of 4; remaining: Phase 4 = `editItem.js`).

https://claude.ai/code/session_013yPg7k1i95Nk349RuYZLG9

---
_Generated by [Claude Code](https://claude.ai/code/session_013yPg7k1i95Nk349RuYZLG9)_