### PR TITLE
fix(#124): reject newReviewInterval ≤ 0 / non-integer with validation error

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,22 @@
-# OmniFocus MCP Server - What's New (v1.30.12)
+# OmniFocus MCP Server - What's New (v1.30.13)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.30.13 Reject non-positive / non-integer `newReviewInterval` in `edit_item` (Issue #124)
+
+**`edit_item(itemType: "project", newReviewInterval: 0)` no longer reports a fake success.** Previously, passing `0` (or any other value that OmniFocus silently refused, e.g. negative numbers or fractional values) would return `✅ Project "<name>" updated successfully (review interval).` while the project's interval, next-review date, and last-reviewed date remained byte-identical — the response said the call had taken effect when it hadn't. The misleading success made failed clear-attempts indistinguishable from real updates.
+
+The Zod schema for `newReviewInterval` is now constrained to **positive integers** (`.int().positive()`). `0`, negatives like `-5`, and non-integers like `1.5` are rejected at the MCP boundary with `"newReviewInterval must be a positive integer"`, before the `editItem` handler runs. Legitimate positive integers continue to work unchanged.
+
+**Surface change for callers.** The rejection surfaces as an MCP `InvalidParams` protocol error (in Claude, typically an "Error calling tool" red-flag), *not* as a tool result with `isError: true` and *not* as a `{ success: false, error: "…" }` shape from the underlying script. The substring `"newReviewInterval must be a positive integer"` appears inside the JSON-stringified Zod issues array. Callers that previously branched on the tool-result success field will now hit the protocol-error path instead — which is the correct outcome (these values were never valid).
+
+**Reachability.** The fix closes the gap surfaced by the [v1.30.12 reachability note](#v1.30.12-surface-review-interval-template-lookup-error-in-edit_item-issue-110-phase-4-closes-110): the no-interval state remains unconstructible from the MCP today (`add_project` still auto-assigns a 7-day default; OmniFocus appears to require every project to have an interval), but the misleading-success path that hid that fact is now gone. The Phase 4 `templateError` plumbing in `editItem.js` is unchanged.
+
+**Forward-compat note.** `batch_edit_items` does not currently expose `newReviewInterval`. If review-interval support is ever added to the batch tool, the same `.int().positive()` constraint should travel with it so the two entry points agree.
+
+**Impact.** No change to legitimate review-interval updates. Calls that pass `0`, negative integers, or fractional values — previously silent-success or undefined-behaviour — now produce a clear validation error.
+
+---
 
 ## v1.30.12 Surface review-interval template-lookup error in edit_item (Issue #110, Phase 4 — closes #110)
 

--- a/docs/superpowers/plans/2026-05-26-issue-124-plan.md
+++ b/docs/superpowers/plans/2026-05-26-issue-124-plan.md
@@ -1,0 +1,127 @@
+# Issue #124 — reject `newReviewInterval: 0` with a validation error
+
+- **Date:** 2026-05-26
+- **Issue:** [#124](https://github.com/mojenmojen/of-mcp/issues/124) — `edit_item: newReviewInterval: 0 silently no-ops while reporting success`
+- **Severity (per issue body):** Low — misreports outcome of a no-op; no data corruption.
+- **Server baseline:** v1.30.12 (`main` @ `4267d7c`).
+- **Target release:** v1.30.13 (patch bump — bugfix, no new tool surface).
+- **Branch:** `fix/issue-124-reject-zero-review-interval`
+- **PR title:** `fix(#124): reject newReviewInterval ≤ 0 / non-integer with validation error`
+
+## 1. The bug, restated
+
+`edit_item({ itemType: "project", id, newReviewInterval: 0 })` reaches `src/utils/omnifocusScripts/editItem.js:419` (`reviewInterval.steps = 0`). OmniFocus silently refuses the assignment, but the JS path still pushes `"review interval"` into `changedProperties` and returns `success: true`. The MCP response then reads:
+
+> ✅ Project "<name>" updated successfully (review interval).
+
+…while `get_project_by_id` on the same project shows the previous interval, next-review date, and last-reviewed date byte-identical to before the call. The misleading success is what the issue asks us to fix.
+
+The bug surfaced during the Phase 4 (#110) smoke test on 2026-05-26; TC3 of that plan required a no-interval project, `add_project` auto-assigns a 7-day default, and `newReviewInterval: 0` was tried as a "clear" — yielding this silent-success.
+
+## 2. Approach: validate at the Zod boundary
+
+A single edit in `src/tools/definitions/editItem.ts:49`.
+
+**Current:**
+
+```ts
+newReviewInterval: z.number().optional().describe("Set new review interval in days. Only applies to projects."),
+```
+
+**Proposed:**
+
+```ts
+newReviewInterval: z
+  .number()
+  .int("newReviewInterval must be a positive integer")
+  .positive("newReviewInterval must be a positive integer")
+  .optional()
+  .describe("Set new review interval in days (must be a positive integer). Only applies to projects."),
+```
+
+### Why the Zod boundary, not an inline `editItem.js` guard
+
+| Aspect | Zod (chosen) | Inline `.js` guard |
+| --- | --- | --- |
+| Runs before | Any AppleScript / OmniJS round-trip | After the script has been compiled and dispatched |
+| Error shape | Standard MCP Zod validation error — same format clients already handle for every other tool input | Custom `{ success: false, error: "…" }` JSON parsed by the TS primitive |
+| Reachability of the silent-success code in `editItem.js:419` | Becomes unreachable from the MCP — the bad value never arrives | Still reachable; we'd have to add a redundant guard |
+| Defense-in-depth value | Low — the only public entry is the MCP; the primitive isn't an external API | Would be dead code in practice |
+| Maintenance | One constraint chain | Two places to keep in sync if the rule ever changes |
+
+The Phase 4 fix (PR #123) went the other way — pushing surfacing into `editItem.js` — because *that* bug's failure mode was a swallowed exception inside the script. #124's failure mode is an invalid input value that the script accepts without error. Input validation belongs at the input boundary; surfacing belongs where the data lives. Different problems, different layers.
+
+### Why `.int().positive()` rather than just rejecting literal `0`
+
+The issue body's recommended error wording is `newReviewInterval must be a positive integer`. That message implies a domain (positive integers), not a single forbidden value. The broader constraint:
+
+- catches `0` (the reported case),
+- catches negative values like `-5` (almost certainly the same silent-success path; not verified by the reporter but covered by the same code),
+- catches fractional values like `1.5` (OmniFocus's `reviewInterval.steps` field is integer-typed; what it does with a float is undefined behaviour we shouldn't allow through).
+
+The same error message attaches to both `.int()` and `.positive()` so the user-facing error is stable across all three failure modes.
+
+### Why `.optional()` stays last
+
+Callers that omit `newReviewInterval` entirely must continue to work — this fix tightens the domain of the *provided* value, not the requirement to provide one.
+
+## 3. Out-of-scope (deliberately)
+
+- **`editItem.js` itself** — no edits. The Phase 4 `templateError` plumbing added in PR #123 is preserved exactly. The newly-unreachable success-with-no-op branch (`steps = 0`) stays in place; removing it would expand the diff without changing observable behaviour.
+- **`batch_edit_items`** — verified at `src/tools/definitions/batchEditItems.ts:11-50` and confirmed against the primitive + `.js` script: it does not expose `newReviewInterval` (or `newNextReviewDate`). There is no second entry path to patch. If review-interval support is ever added to the batch tool, the same constraint should travel with it; I'll record that as a forward note in WHATS_NEW rather than pre-emptively wiring it.
+- **`markReviewed`, `newNextReviewDate`, `newProjectStatus`** — separate fields, not part of #124.
+- **OmniFocus UI behaviour with `0` set via AppleScript** — not investigated. Even if OmniFocus would accept `0`, the issue's reasoning (review intervals are mandatory for every project) stands, and the fix is the same.
+
+## 4. Smoke-test plan (separate file)
+
+Will be written to `docs/test-plans/issue-124-newreviewinterval-zero-rejection.md` after this plan is approved, matching the Phase 2/3/4 cadence. Sketch:
+
+**Important error-surface detail.** TC1–TC3 expect an MCP `InvalidParams` protocol error thrown by the SDK's `safeParseAsync` *before* `editItem`'s handler runs. In Claude this typically materialises as an "Error calling tool" message, not a tool result with `isError: true` or a `{ success: false, error: "…" }` shape from `editItem.js`. The error payload is a JSON-stringified Zod issues array; the substring `"newReviewInterval must be a positive integer"` will appear inside it, but the wrapper is the SDK's, not ours. TC4 is the only case that produces a normal tool-result `success: true` response. The smoke-test plan document should restate this once at the top so the tester knows which UI surface to watch.
+
+| TC | Call | Expected | Pre-fix behaviour |
+| --- | --- | --- | --- |
+| TC1 | `edit_item(itemType: "project", id: <scratch>, newReviewInterval: 0)` | Zod validation error containing `"newReviewInterval must be a positive integer"` | Silent success (the reported bug) |
+| TC2 | `edit_item(itemType: "project", id: <scratch>, newReviewInterval: -5)` | Same validation error | Presumed silent success (same code path) |
+| TC3 | `edit_item(itemType: "project", id: <scratch>, newReviewInterval: 1.5)` | Same validation error | Presumed truncation/rounding inside OmniFocus |
+| TC4 | `edit_item(itemType: "project", id: <scratch>, newReviewInterval: 7)` | Success, `get_project_by_id` shows `Review Interval: 7 days` | Already works; regression check |
+
+Each case is followed by a `get_project_by_id` snapshot to verify the response matches actual state. Scratch project name: `issue-124-validation-test` (placeholder, no personal data per the `of-mcp` public-repo policy).
+
+## 5. Mechanical follow-ups (per CLAUDE.md)
+
+- `package.json` version: `1.30.12` → `1.30.13`.
+- `docs/WHATS_NEW.md`: add a `## v1.30.13` section describing the rejection of `newReviewInterval ≤ 0` and non-integer values; cross-reference #124; note the forward-compat point about `batch_edit_items`.
+- `README.md`: re-check after the edit. Likely no change — no new tools, and the field's own `describe()` text is now self-explanatory.
+- Sanitization: keep `issue-124-validation-test` (or similar generic placeholder) in committed docs per [[of-mcp-public-repo-no-personal-data]]; never paste real OmniFocus project names.
+
+## 6. Build + verify loop
+
+1. Edit `src/tools/definitions/editItem.ts`.
+2. `npm run build` — TS compile catches any Zod-chain mistakes.
+3. Restart the MCP server (TS layer change, per [[omnijs-scripts-loaded-from-disk]] — only `.js` scripts hot-reload; `.ts` edits need rebuild + restart).
+4. MoJen runs the smoke test plan against the rebuilt server.
+5. If all four TCs pass, commit on the `fix/issue-124-…` branch, push, open PR.
+6. Self-merge ritual per [[of-mcp-pr-merge-process]]: `gh pr merge <#> --merge --admin --delete-branch`.
+
+## 7. Confidence
+
+- **High** that the schema-layer fix is the right architectural choice — the issue's recommended option (reject), the right layer (Zod), and the right scope (positive integers, not just literal `0`).
+- **High** that `batch_edit_items` doesn't need a parallel fix — verified by direct grep + schema read.
+- **Medium** that no README change is needed — will re-confirm after the edit.
+- **High** that the diff is genuinely tiny (one Zod chain), so risk to other `edit_item` paths is near-zero.
+
+## 8. One open question for MoJen
+
+The issue body ranks "reject 0" as the right answer. This plan implements that *plus* rejecting negatives and non-integers under the same error message. Confidence is high that broader is right (one stable error message; no sensible behaviour for any of these), but it is slightly more than the literal letter of the issue.
+
+If you'd rather scope tighter — only reject literal `0`, leave negatives/floats to fall through into OmniFocus — say so and the change becomes:
+
+```ts
+newReviewInterval: z
+  .number()
+  .refine((n) => n !== 0, { message: "newReviewInterval must not be 0" })
+  .optional()
+  .describe(...)
+```
+
+Default proposal: the broader `.int().positive()` chain.

--- a/docs/test-plans/issue-124-newreviewinterval-zero-rejection.md
+++ b/docs/test-plans/issue-124-newreviewinterval-zero-rejection.md
@@ -1,0 +1,190 @@
+# Smoke Test — Issue #124 (`edit_item` `newReviewInterval` must be a positive integer)
+
+**Branch:** `fix/issue-124-reject-zero-review-interval`
+**Version under test:** `1.30.13`
+**Tool affected:** `edit_item` (only when called with `newReviewInterval`)
+**Run in:** a Claude Code (or other MCP client) session connected to **OmniFocus** on macOS.
+
+---
+
+## What changed (context for the tester)
+
+Before this change, `edit_item(itemType: "project", newReviewInterval: 0)` returned a `success: true` tool result while OmniFocus silently refused the underlying assignment — the project's review interval, next-review date, and last-reviewed date were byte-identical to before the call, but the response read `✅ Project "<name>" updated successfully (review interval)`. The misleading success made a failed clear-attempt indistinguishable from a real update.
+
+The fix is a single Zod-schema tightening at the MCP boundary. The `newReviewInterval` field is now constrained to **positive integers** — Zod rejects `0`, negatives, and non-integers (e.g. `1.5`) before the `edit_item` handler runs. All three failure cases share the error message `"newReviewInterval must be a positive integer"`.
+
+**Important error-surface detail.** Because the rejection happens in the MCP SDK's `safeParseAsync` before `editItem`'s handler runs, the failure surfaces as an **MCP `InvalidParams` protocol error**, *not* a tool result with `isError: true` and not a `{ success: false, error: "…" }` shape from `editItem.js`. In Claude this typically materialises as an "Error calling tool" message containing a JSON-stringified Zod issues array; the substring `"newReviewInterval must be a positive integer"` will appear inside that array, but the wrapper is the SDK's, not ours. Only TC5 (the regression check) produces a normal tool-result `success: true` response.
+
+`editItem.js` itself is unchanged — the silent-success line (`reviewInterval.steps = 0` at script line 419) is still in place but is no longer reachable from the MCP, because the bad value never arrives.
+
+---
+
+## Setup (do this once before the test cases)
+
+1. **Build this branch** so the MCP server runs v1.30.13:
+   ```bash
+   cd /Users/mojen/dev/of-mcp
+   git checkout fix/issue-124-reject-zero-review-interval
+   npm run build
+   ```
+2. **Point your MCP client at this build** (`dist/server.js` in this repo) and **restart the session** so it loads the new build. Schema changes live in the TypeScript layer, so a server restart is required — `.js` script hot-reload alone is not enough.
+3. Have OmniFocus running with your normal database. Any project (existing or newly created) is fine; TC5 walks you through creating a scratch project so nothing in your live data gets touched.
+
+---
+
+## TC1 — Version gate (must pass before anything else)
+
+**Why:** confirms you're testing this branch's build, not an older one.
+
+**Do:** ask Claude to run the `get_server_version` tool.
+
+**Expect:** the returned JSON has `"version": "1.30.13"`.
+
+- [ ] **PASS** — version is `1.30.13`
+- [ ] **FAIL** — any other version (stop; you're testing the wrong build — revisit Setup)
+
+---
+
+## TC2 — Reject `newReviewInterval: 0` (the reported bug)
+
+**Do:** create a scratch project for safety, then attempt the bug-trigger call:
+
+```
+add_project(name: "issue-124-validation-test")
+   → captures project id, e.g. <pid>
+
+edit_item(itemType: "project", id: "<pid>", newReviewInterval: 0)
+```
+
+**Expect:**
+- An **MCP `InvalidParams`** protocol error (in Claude, typically a red-flagged "Error calling tool" surface, not a normal tool result).
+- The error payload contains the string `"newReviewInterval must be a positive integer"`.
+- **No** `✅ Project "..." updated successfully` text appears.
+- `get_project_by_id("<pid>")` afterwards still shows `Review Interval: 7 days` (the `add_project` default) — the call was rejected, not no-op'd.
+
+**Pass criteria:** the misleading success is gone; the caller now sees an explicit rejection.
+
+- [ ] **PASS** — `InvalidParams` error with the expected substring; project state unchanged
+- [ ] **FAIL** — tool returns success, or no error, or unexpected wording (record output)
+
+---
+
+## TC3 — Reject `newReviewInterval: -5` (negative integer)
+
+**Why:** same code path, broader-domain check. Confirms the rejection covers the whole "not a positive integer" class, not just literal `0`.
+
+**Do:**
+
+```
+edit_item(itemType: "project", id: "<pid>", newReviewInterval: -5)
+```
+
+**Expect:** identical to TC2 — `InvalidParams` error containing `"newReviewInterval must be a positive integer"`; project state still shows the previous interval.
+
+- [ ] **PASS** — same error surface as TC2
+- [ ] **FAIL** — accepted, or different wording (record output)
+
+---
+
+## TC4 — Reject `newReviewInterval: 1.5` (non-integer)
+
+**Why:** confirms the `.int()` constraint trips for fractional values, since OmniFocus's `reviewInterval.steps` is integer-typed and we don't want undefined-behaviour rounding through the bridge.
+
+**Do:**
+
+```
+edit_item(itemType: "project", id: "<pid>", newReviewInterval: 1.5)
+```
+
+**Expect:** same as TC2 / TC3 — `InvalidParams` error containing `"newReviewInterval must be a positive integer"`; project state unchanged.
+
+- [ ] **PASS** — same error surface as TC2
+- [ ] **FAIL** — accepted (record what the resulting interval ended up being), or different wording
+
+---
+
+## TC5 — Set `newReviewInterval: 14` succeeds (regression check)
+
+**Why:** the only positive integer the fix should still accept is, well, a positive integer. This confirms the happy path still works — that we haven't broken legitimate review-interval updates.
+
+**Do:**
+
+```
+edit_item(itemType: "project", id: "<pid>", newReviewInterval: 14)
+```
+
+**Expect:**
+- A **normal tool-result success** response (`✅ Project "issue-124-validation-test" updated successfully (review interval).` or equivalent), `success: true`, `changedProperties` mentioning `review interval`.
+- `get_project_by_id("<pid>")` afterwards shows `Review Interval: 14 days` and the `Next Review` date has shifted accordingly.
+
+**Pass criteria:** the existing-interval branch in `editItem.js` (the one that always worked) is unaffected by the schema change.
+
+- [ ] **PASS** — success response; interval actually changed to 14 days
+- [ ] **FAIL** — error, or interval didn't change (record output)
+
+---
+
+## Cleanup
+
+Once the test cases are done, mark the scratch project as dropped (do **not** use `remove_item` — the "never delete" rule applies to test artefacts so cleanup remains recoverable):
+
+```
+edit_item(itemType: "project", id: "<pid>", newProjectStatus: "dropped")
+```
+
+If you'd rather keep it active, that's fine — but it serves no further purpose. A dropped project remains in the database and can be reactivated later if needed.
+
+---
+
+## Red flags (treat as FAIL)
+
+- TC2, TC3, or TC4 returns a tool-result success (the rejection isn't firing — schema constraint not in effect; revisit Setup, particularly the restart).
+- TC2, TC3, or TC4 returns a different error wording (the message strings on `.int()` / `.positive()` aren't being picked up — check the schema edit in `src/tools/definitions/editItem.ts:49`).
+- TC5 regresses (legitimate positive integers are now being rejected — the `.optional()` is in the wrong place or the constraint is too tight).
+- `get_server_version` ≠ `1.30.13` → you tested the wrong build; redo Setup.
+
+---
+
+## Results
+
+| Test | Result | Notes |
+|------|--------|-------|
+| TC1 Version gate | ☑ PASS ☐ FAIL | `get_server_version` → `1.30.13` (branch `fix/issue-124-reject-zero-review-interval`) |
+| TC2 Reject `0` | ☑ PASS ☐ FAIL | MCP `-32602` InvalidParams; Zod `code: "too_small"`, `inclusive: false`; message `"newReviewInterval must be a positive integer"`; project state byte-identical post-call |
+| TC3 Reject `-5` | ☑ PASS ☐ FAIL | Same `.positive()` path as TC2 (`code: "too_small"`); same custom message; state unchanged |
+| TC4 Reject `1.5` | ☑ PASS ☐ FAIL | Different Zod path: `.int()` (`code: "invalid_type"`, expected integer, received float); same custom message; state unchanged |
+| TC5 `14` regression check | ☑ PASS ☐ FAIL | Normal success; `Review Interval` 7 → 14; `Next Review` correctly recomputed to 2026-06-09 |
+
+**Overall:** ☑ PASS ☐ FAIL
+
+**Run:** 2026-05-26 / MoJen (Claude Code, Seshat) / branch `fix/issue-124-reject-zero-review-interval` (fix uncommitted, working tree only), server v1.30.13. Two adjacent findings recorded below.
+
+---
+
+## Findings from run
+
+### 1. Version gate alone is not sufficient evidence of a fresh build
+
+The first TC2 attempt in this run reproduced the original #124 bug verbatim: `edit_item(newReviewInterval: 0)` returned `✅ Project "issue-124-validation-test" updated successfully (review interval).`, with `get_project_by_id` confirming a byte-identical no-op, despite `get_server_version` already reporting the target `1.30.13` at the time of the call. After running `npm run build` and reconnecting the MCP client, the retry passed cleanly with the expected `InvalidParams` rejection.
+
+Root cause: `package.json`'s version can reach the running server via runtime read, independently of whether the TypeScript layer was actually recompiled. So `get_server_version` matching the target version is a necessary but insufficient gate. The test plan's existing Setup warning ("Schema changes live in the TypeScript layer, so a server restart is required — `.js` script hot-reload alone is not enough") is empirically vindicated.
+
+Suggestion for a future iteration of this plan: either add a build-freshness diagnostic to Setup (e.g. compare `dist/server.js` mtime against `src/tools/definitions/editItem.ts` mtime), or treat TC2 itself as the operational gate. If TC2's rejection does not fire, the build is stale regardless of what TC1 reports.
+
+### 2. Rejection error string is double-prefixed
+
+The MCP errors returned on TC2/TC3/TC4 have the form:
+
+```
+MCP error -32602: MCP error -32602: Invalid arguments for tool edit_item: [ ...Zod issues array... ]
+```
+
+The `MCP error -32602:` token appears twice. The substring `"newReviewInterval must be a positive integer"` that the plan asks for is intact inside the Zod issues array, so this does not change the verdict. The doubled prefix is a cosmetic wrapping bug somewhere in the error-render path; could be the server's wrapping, the MCP SDK's wrapping, or the Claude client's. Worth filing as a separate low-priority issue if clean error surfaces are wanted.
+
+---
+
+## Notes — what's already been verified without OmniFocus
+
+- `npm run build` compiles cleanly; the new Zod chain `z.number().int("…").positive("…").optional()` is well-formed in the installed Zod version (3.25.76).
+- `batch_edit_items` does not expose `newReviewInterval` (verified in `src/tools/definitions/batchEditItems.ts:11-50` and confirmed by grep across the primitive + script). There is no second entry path that bypasses the new constraint.
+- `server.ts` is the sole consumer of the `editItem` definition; nothing calls the primitive directly. The Zod boundary is therefore the *only* boundary, and the fix sits at the right layer.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.30.12",
+  "version": "1.30.13",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/tools/definitions/editItem.ts
+++ b/src/tools/definitions/editItem.ts
@@ -46,7 +46,12 @@ export const schema = z.object({
 
   // Project review fields
   markReviewed: z.boolean().optional().describe("Mark project as reviewed (advances next review date by interval). Only applies to projects."),
-  newReviewInterval: z.number().optional().describe("Set new review interval in days. Only applies to projects."),
+  newReviewInterval: z
+    .number()
+    .int("newReviewInterval must be a positive integer")
+    .positive("newReviewInterval must be a positive integer")
+    .optional()
+    .describe("Set new review interval in days (must be a positive integer). Only applies to projects."),
   newNextReviewDate: z.string().optional().describe("Set next review date directly (ISO format YYYY-MM-DD). Only applies to projects.")
 });
 


### PR DESCRIPTION
Closes #124.

## Summary

Before this change, `edit_item(itemType: "project", newReviewInterval: 0)` returned `✅ Project "<name>" updated successfully (review interval).` while OmniFocus silently refused the underlying assignment. The misleading success made failed clear-attempts indistinguishable from real updates.

This PR tightens the Zod schema on `newReviewInterval` in `src/tools/definitions/editItem.ts` to `.int().positive()` with the message `"newReviewInterval must be a positive integer"`. Values that OmniFocus would silently refuse (`0`, negatives, fractional values like `1.5`) are now rejected at the MCP boundary with an `InvalidParams` protocol error before the `editItem` handler runs. Legitimate positive integers continue to work unchanged.

`editItem.js` itself is unchanged — the silent-success line (`reviewInterval.steps = 0`) is still in place but is no longer reachable from the MCP because the bad value never arrives.

## Why Zod-layer validation, not an inline guard in `editItem.js`

Catching at the schema layer means the bad value never pays a script round-trip. The MCP SDK's `safeParseAsync` validates before the handler runs, and the caller sees a clean `InvalidParams` error rather than a custom `{ success: false, error: "…" }` shape from the script. Defense-in-depth in the script would have been redundant: `server.ts` is the sole consumer of the `editItem` definition; nothing bypasses Zod.

`batch_edit_items` does not currently expose `newReviewInterval` (verified in `src/tools/definitions/batchEditItems.ts:11-50` and confirmed by grep across the primitive + script), so there is no second entry path to harden. If review-interval support is ever added to the batch tool, the same `.int().positive()` constraint should travel with it.

## Smoke test

Live-verified against OmniFocus on 2026-05-26 — TC1–TC5 all PASS. Plan and results live in `docs/test-plans/issue-124-newreviewinterval-zero-rejection.md`. Test surface covered:

| TC | Input | Expected | Outcome |
| --- | --- | --- | --- |
| TC1 | `get_server_version` | `1.30.13` | PASS |
| TC2 | `newReviewInterval: 0` | MCP `InvalidParams`, message contains "positive integer" | PASS (`code: "too_small"`) |
| TC3 | `newReviewInterval: -5` | Same | PASS (`code: "too_small"`) |
| TC4 | `newReviewInterval: 1.5` | Same | PASS (`code: "invalid_type"` — exercises `.int()` separately) |
| TC5 | `newReviewInterval: 14` (regression) | Normal success; interval updated | PASS |

## Adjacent findings (filed as separate issues)

The smoke-test run surfaced two follow-ups that aren't in scope for this PR:

1. **#126** — `get_server_version` alone is not sufficient evidence of a fresh build after TS-layer changes. The first TC2 attempt reproduced the original #124 bug verbatim despite `get_server_version` reporting the target version; root cause is that `package.json` is read at startup independently of whether the TypeScript layer was recompiled. Proposes either an mtime-based diagnostic in test-plan Setup or a `buildHash` returned by `get_server_version`.
2. **#127** — MCP error strings have a doubled `MCP error -32602:` prefix on `InvalidParams` rejections. Cosmetic; substring assertions still work. Likely SDK or transport-layer double-wrapping; needs minimal-repro investigation.

## Design plan

Full rationale (architectural choice, scope question, what's deliberately out of scope, reviewer findings, smoke-test results) lives at `docs/superpowers/plans/2026-05-26-issue-124-plan.md`.

## Versioning

`1.30.12` → `1.30.13` (patch — bugfix, no new tool surface). `docs/WHATS_NEW.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)