### PR TITLE
fix(#118): echo get_completion_stats period as local date for UTC+ users

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,15 @@
-# OmniFocus MCP Server - What's New (v1.32.0)
+# OmniFocus MCP Server - What's New (v1.32.1)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.32.1 Fix `get_completion_stats` period echo off-by-one for UTC+ users (#118)
+
+**`get_completion_stats` now echoes `period.start` / `period.end` as the correct local date for UTC+ users.**
+The script built the echoed range with `completedAfter.toISOString().split('T')[0]`. Because `completedAfter` / `completedBefore` are local-midnight `Date` objects from `parseLocalDate(...)`, `toISOString()` converts them back to UTC — in a UTC+10 environment, local midnight April 28 became `"2026-04-27"`, reporting the range a day early. The keys are now built from local year/month/date components via a shared `toLocalDateKey(date)` helper in `lib/sharedUtils.js`.
+
+**Display-only.** This affected only the echoed range in the response, not which tasks were counted — the completion-date comparisons use the `Date` objects directly and were always correct. Same bug class as the forecast fix in #114.
+
+---
 
 ## v1.32.0 Folder path disambiguation and server version fix
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "of-mcp",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "of-mcp",
-      "version": "1.32.0",
+      "version": "1.32.1",
       "license": "MIT",
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/utils/omnifocusScripts/completionStats.js
+++ b/src/utils/omnifocusScripts/completionStats.js
@@ -1,5 +1,5 @@
 // OmniJS script to get completion statistics grouped by project, tag, or folder
-// parseLocalDate is provided by sharedUtils.js
+// parseLocalDate and toLocalDateKey are provided by sharedUtils.js
 (() => {
   try {
     const args = typeof injectedArgs !== 'undefined' ? injectedArgs : {};
@@ -135,8 +135,8 @@
     return JSON.stringify({
       success: true,
       period: {
-        start: completedAfter ? completedAfter.toISOString().split('T')[0] : null,
-        end: completedBefore ? completedBefore.toISOString().split('T')[0] : null
+        start: toLocalDateKey(completedAfter),
+        end: toLocalDateKey(completedBefore)
       },
       groupBy: groupBy,
       totalCompleted: totalCompleted,

--- a/src/utils/omnifocusScripts/lib/sharedUtils.js
+++ b/src/utils/omnifocusScripts/lib/sharedUtils.js
@@ -67,6 +67,22 @@ function formatDate(date) {
 }
 
 /**
+ * Build a local YYYY-MM-DD date key from a Date.
+ * Uses local year/month/date components — toISOString() would convert to UTC,
+ * shifting the day for UTC+ users (see #114, #118).
+ * @param {Date|null|undefined} date - The date to format
+ * @returns {string|null} - Local date key (YYYY-MM-DD) or null if date is falsy
+ */
+function toLocalDateKey(date) {
+  if (!date) return null;
+  const d = new Date(date);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/**
  * Build the full ancestor path for a folder (e.g. "Work > Projects > Active").
  * Walks up the parent chain. Returns the folder's own name if it has no parent.
  * @param {Folder} folder - An OmniFocus Folder object


### PR DESCRIPTION
## Summary

`get_completion_stats` echoed `period.start` / `period.end` one day early for users east of UTC. The script derived the echoed range with `completedAfter.toISOString().split('T')[0]`; because `completedAfter` / `completedBefore` are **local**-midnight `Date` objects from `parseLocalDate(...)`, `toISOString()` converts them back to UTC, so in UTC+10 local midnight April 28 became `"2026-04-27"`.

**Display-only:** this affected only the echoed range, not which tasks were counted — the completion-date comparisons use the `Date` objects directly and were always correct. Same bug class as the forecast fix in #114.

## Changes

- Add a shared `toLocalDateKey(date)` helper to `lib/sharedUtils.js` — builds `YYYY-MM-DD` from local year/month/date components; returns `null` for falsy input.
- `completionStats.js` now derives `period.start` / `period.end` via the helper instead of `toISOString().split('T')[0]`.
- Bump version `1.32.0 → 1.32.1`; add `docs/WHATS_NEW.md` entry.

Forecast (`forecastTasks.js`, fixed in #114) is intentionally left untouched.

## Test plan

- Under `TZ=Australia/Sydney`: `toLocalDateKey(parseLocalDate("2026-04-28"))` returns `"2026-04-28"`, whereas the old `.toISOString().split('T')[0]` returned `"2026-04-27"`. ✅
- `node --check` passes on both modified scripts.
- Runtime availability of the helper is guaranteed: `parseLocalDate` (same `sharedUtils.js`, injected identically) is already called in `completionStats.js`.

The malformed-date edge case (the non-throwing helper vs. the old `toISOString` throw) is unreachable through the MCP boundary — `completedAfter` / `completedBefore` are constrained to `^\d{4}-\d{2}-\d{2}$` by the Zod schema before the handler runs.

Closes #118.

Follow-up: #133 (make OmniJS-side pure helpers unit-testable + add timezone tests, sibling to #119) would have caught this bug class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
