### PR TITLE
test(#119): shared parseLocalDate helper + timezone unit tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,15 @@ npm run dev
 # Start the server
 npm run start
 
-# Test (manual testing required with OmniFocus)
-npm run test
+# Run the automated unit tests
+# (esbuild-transpiles the pure date utils, then runs node:test; no full tsc
+#  build or OmniFocus needed — esbuild is used because the full tsc build is
+#  known to hang/OOM on some systems, see build:fast)
+npm test
+
+# OmniFocus integration scripts (tests/test-*.mjs) still require manual runs
+# against a live OmniFocus, e.g.:
+node tests/test-review-feature.mjs
 ```
 
 The build process compiles TypeScript to JavaScript and copies OmniJS script files to the dist directory.

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,16 @@
-# OmniFocus MCP Server - What's New (v1.32.1)
+# OmniFocus MCP Server - What's New (v1.32.2)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.32.2 Harden TS date parsing: shared `parseLocalDate` helper + timezone unit tests (#119)
+
+**Internal hardening, no behaviour change for users.** Follow-up to #114.
+
+The bare-`YYYY-MM-DD` → local-`Date` parsing that #114 added inline in two TypeScript spots (`formatDateSafe` and the forecast classifier) is now consolidated into a single exported `parseLocalDate(dateString)` in `src/utils/dateUtils.ts` — the TS-side parallel to the OmniJS `parseLocalDate()` in `lib/sharedUtils.js`, hardened to return `null` for missing or invalid input. `formatDateSafe` now delegates to it, and the forecast TODAY/TOMORROW/OVERDUE/FUTURE bucketing is extracted into a pure, testable `classifyForecastDate(dateString, now)`.
+
+**First automated tests.** `npm test` now runs a timezone unit suite (`tests/dateUtils.test.mjs`, Node's built-in `node:test`, no new dependencies) that exercises the bare-date path under both a UTC− zone (`America/Los_Angeles`) and a UTC+ zone (`Australia/Sydney`), asserting cross-zone invariance rather than a locale-specific string. This locks in the #114 fix and the invalid-date guard added during its review, which were previously invisible to any UTC-based run. The OmniFocus integration scripts (`tests/test-*.mjs`) remain manual.
+
+---
 
 ## v1.32.1 Fix `get_completion_stats` period echo off-by-one for UTC+ users (#118)
 

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -4,11 +4,13 @@
 
 ## v1.32.2 Harden TS date parsing: shared `parseLocalDate` helper + timezone unit tests (#119)
 
-**Internal hardening, no behaviour change for users.** Follow-up to #114.
+Follow-up to #114 — internal hardening plus one small forecast display fix.
 
-The bare-`YYYY-MM-DD` → local-`Date` parsing that #114 added inline in two TypeScript spots (`formatDateSafe` and the forecast classifier) is now consolidated into a single exported `parseLocalDate(dateString)` in `src/utils/dateUtils.ts` — the TS-side parallel to the OmniJS `parseLocalDate()` in `lib/sharedUtils.js`, hardened to return `null` for missing or invalid input. `formatDateSafe` now delegates to it, and the forecast TODAY/TOMORROW/OVERDUE/FUTURE bucketing is extracted into a pure, testable `classifyForecastDate(dateString, now)`.
+The bare-`YYYY-MM-DD` → local-`Date` parsing that #114 added inline in two TypeScript spots (`formatDateSafe` and the forecast classifier) is now consolidated into a single exported `parseLocalDate(dateString)` in `src/utils/dateUtils.ts` — the TS-side parallel to the OmniJS `parseLocalDate()` in `lib/sharedUtils.js`, hardened to return `null` for missing or invalid input (and to round-trip years 0–99 rather than mapping them to the 1900s). `formatDateSafe` now delegates to it, and the forecast OVERDUE/TODAY/TOMORROW/FUTURE bucketing is extracted into a pure, testable `classifyForecastDate(date, now)`.
 
-**First automated tests.** `npm test` now runs a timezone unit suite (`tests/dateUtils.test.mjs`, Node's built-in `node:test`, no new dependencies) that exercises the bare-date path under both a UTC− zone (`America/Los_Angeles`) and a UTC+ zone (`Australia/Sydney`), asserting cross-zone invariance rather than a locale-specific string. This locks in the #114 fix and the invalid-date guard added during its review, which were previously invisible to any UTC-based run. The OmniFocus integration scripts (`tests/test-*.mjs`) remain manual.
+**Forecast fix:** `classifyForecastDate` now uses calendar arithmetic for "tomorrow" instead of a fixed `+24h`, so on the two daylight-saving transition days a year the day after the change is again labelled `⏰ TOMORROW` rather than a plain weekday header. The forecast summary count also reflects only the dates actually rendered.
+
+**First automated tests.** `npm test` runs a timezone unit suite (`tests/dateUtils.test.mjs`, Node's built-in `node:test`, no new dependencies) that exercises the bare-date path under both a UTC− zone (`America/Los_Angeles`) and a UTC+ zone (`Australia/Sydney`), asserting cross-zone (and DST-transition) invariance rather than locale-specific strings. It builds the one pure module under test with esbuild, since the full `tsc` build is known to hang on some setups (see `build:fast`). This locks in the #114 fix and the invalid-date guard added during its review, which were previously invisible to any UTC-based run. The OmniFocus integration scripts (`tests/test-*.mjs`) remain manual.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "tsc -w",
     "prepublishOnly": "npm run build",
     "test": "npm run test:unit",
-    "test:unit": "esbuild src/utils/dateUtils.ts --outfile=dist/utils/dateUtils.js --format=esm --platform=node && node --test tests/*.test.mjs"
+    "test:unit": "esbuild src/utils/dateUtils.ts --bundle --outfile=dist/test-build/dateUtils.mjs --format=esm --platform=node && node --test tests/*.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {
@@ -14,7 +14,8 @@
     "start": "node dist/server.js",
     "dev": "tsc -w",
     "prepublishOnly": "npm run build",
-    "test": "echo \"Test passed - manual testing required with OmniFocus\""
+    "test": "npm run test:unit",
+    "test:unit": "esbuild src/utils/dateUtils.ts --outfile=dist/utils/dateUtils.js --format=esm --platform=node && node --test tests/*.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.8.0",

--- a/src/tools/primitives/getForecastTasks.ts
+++ b/src/tools/primitives/getForecastTasks.ts
@@ -1,6 +1,6 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
 import { logger } from '../../utils/logger.js';
-import { formatDateSafe } from '../../utils/dateUtils.js';
+import { formatDateSafe, parseLocalDate, classifyForecastDate } from '../../utils/dateUtils.js';
 
 const log = logger.child('getForecastTasks');
 
@@ -48,25 +48,23 @@ export async function getForecastTasks(options: GetForecastTasksOptions = {}): P
           dates.forEach(dateStr => {
             const tasks = data.tasksByDate[dateStr];
             if (!tasks || tasks.length === 0) return;
-            
-            const [year, month, day] = dateStr.split('-').map(Number);
-            const taskDate = new Date(year, month - 1, day);
-            const isToday = taskDate.getTime() === today.getTime();
-            const isTomorrow = taskDate.getTime() === today.getTime() + 24 * 60 * 60 * 1000;
-            const isOverdue = taskDate < today;
-            
+
+            const taskDate = parseLocalDate(dateStr);
+            const category = classifyForecastDate(dateStr, today);
+            if (!taskDate || !category) return; // skip unparseable forecast keys
+
             let dateHeader = '';
-            if (isOverdue) {
+            if (category === 'OVERDUE') {
               dateHeader = `## ⚠️ OVERDUE - ${taskDate.toLocaleDateString()}`;
-            } else if (isToday) {
+            } else if (category === 'TODAY') {
               dateHeader = `## 🔥 TODAY - ${taskDate.toLocaleDateString()}`;
-            } else if (isTomorrow) {
+            } else if (category === 'TOMORROW') {
               dateHeader = `## ⏰ TOMORROW - ${taskDate.toLocaleDateString()}`;
             } else {
               const dayOfWeek = taskDate.toLocaleDateString('en-US', { weekday: 'long' });
               dateHeader = `## 📅 ${dayOfWeek} - ${taskDate.toLocaleDateString()}`;
             }
-            
+
             output += `${dateHeader}\n`;
             
             tasks.forEach((task: any) => {

--- a/src/tools/primitives/getForecastTasks.ts
+++ b/src/tools/primitives/getForecastTasks.ts
@@ -42,16 +42,16 @@ export async function getForecastTasks(options: GetForecastTasksOptions = {}): P
         if (dates.length === 0) {
           output += "🎉 No tasks due in the forecast period - enjoy the calm!\n";
         } else {
-          const today = new Date();
-          today.setHours(0, 0, 0, 0);
-          
+          const now = new Date();
+          let totalTasks = 0;
+
           dates.forEach(dateStr => {
             const tasks = data.tasksByDate[dateStr];
             if (!tasks || tasks.length === 0) return;
 
             const taskDate = parseLocalDate(dateStr);
-            const category = classifyForecastDate(dateStr, today);
-            if (!taskDate || !category) return; // skip unparseable forecast keys
+            if (!taskDate) return; // skip unparseable forecast keys
+            const category = classifyForecastDate(taskDate, now);
 
             let dateHeader = '';
             if (category === 'OVERDUE') {
@@ -81,12 +81,12 @@ export async function getForecastTasks(options: GetForecastTasksOptions = {}): P
                 output += `  📝 ${task.note.trim()}\n`;
               }
             });
-            
+
+            totalTasks += tasks.length; // count only dates we actually rendered
             output += '\n';
           });
-          
+
           // Summary
-          const totalTasks = dates.reduce((sum, date) => sum + data.tasksByDate[date].length, 0);
           output += `📊 **Summary**: ${totalTasks} task${totalTasks === 1 ? '' : 's'} in forecast\n`;
         }
       } else {

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -15,6 +15,9 @@
  * This is the TypeScript-side parallel to `parseLocalDate()` in
  * `lib/sharedUtils.js` (the OmniJS helper, which is not importable from TS),
  * hardened to return `null` for unparseable input so callers can fail safely.
+ * NOTE: the OmniJS twin is NOT yet hardened (it rolls invalid dates forward and
+ * would throw on null) — keep the two in sync when changing parsing rules; #133
+ * tracks making the OmniJS side testable and hardened.
  *
  * @param dateString - ISO date string (YYYY-MM-DD or full ISO), or null/undefined
  * @returns A local-time Date, or null if the input is missing or invalid
@@ -26,6 +29,9 @@ export function parseLocalDate(dateString: string | null | undefined): Date | nu
   if (bareDate) {
     const [, y, m, d] = bareDate.map(Number);
     const date = new Date(y, m - 1, d);
+    // new Date(0..99, ...) maps to years 1900..1999; force the literal year so
+    // dates in years 0-99 round-trip instead of being rejected by the guard below.
+    if (y < 100) date.setFullYear(y);
     // new Date(y, m-1, d) silently rolls overflow forward (month 13 -> next year,
     // day 45 -> next month), so a well-shaped but invalid string like "2026-13-45"
     // would yield a bogus date that isNaN can't catch. Reject anything that doesn't
@@ -58,29 +64,34 @@ export function formatDateSafe(dateString: string | null | undefined): string | 
 export type ForecastDateCategory = 'OVERDUE' | 'TODAY' | 'TOMORROW' | 'FUTURE';
 
 /**
- * Classify a forecast date key (bare `YYYY-MM-DD`) relative to a reference time.
+ * Classify a (local-time) date relative to a reference time, by calendar day.
  *
- * The key is parsed as local time (via {@link parseLocalDate}) so that "today"
- * is judged against the viewer's local day, not UTC — otherwise a date due today
- * would classify as OVERDUE for UTC- viewers. Returns null if the key cannot be
- * parsed.
+ * Both `date` and `now` are reduced to their local calendar day before
+ * comparison, so a task due today classifies as TODAY for the viewer's local day
+ * regardless of timezone. TOMORROW uses calendar arithmetic (not a fixed +24h) so
+ * it stays correct across DST transitions, where a local day is 23h or 25h long.
+ * Parse bare `YYYY-MM-DD` keys with {@link parseLocalDate} (as the callers do) so
+ * they land on local midnight.
  *
- * @param dateString - Forecast date key in `YYYY-MM-DD` form
+ * @param date - The date to classify (only its local calendar day matters)
  * @param now - Reference time (defaults to the current time)
- * @returns The forecast category, or null if the key is invalid
+ * @returns The forecast category
  */
 export function classifyForecastDate(
-  dateString: string,
+  date: Date,
   now: Date = new Date()
-): ForecastDateCategory | null {
-  const date = parseLocalDate(dateString);
-  if (!date) return null;
-
+): ForecastDateCategory {
   const today = new Date(now);
   today.setHours(0, 0, 0, 0);
 
-  if (date.getTime() === today.getTime()) return 'TODAY';
-  if (date.getTime() === today.getTime() + 24 * 60 * 60 * 1000) return 'TOMORROW';
-  if (date < today) return 'OVERDUE';
+  const tomorrow = new Date(today);
+  tomorrow.setDate(today.getDate() + 1); // calendar arithmetic — DST-safe, unlike +24h
+
+  const day = new Date(date);
+  day.setHours(0, 0, 0, 0);
+
+  if (day.getTime() === today.getTime()) return 'TODAY';
+  if (day.getTime() === tomorrow.getTime()) return 'TOMORROW';
+  if (day < today) return 'OVERDUE';
   return 'FUTURE';
 }

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -3,18 +3,25 @@
  */
 
 /**
- * Safely formats a date string to locale date string.
- * Returns null for invalid, null, or undefined date inputs.
+ * Parse a date string as local time.
  *
- * @param dateString - ISO date string, or null/undefined
- * @returns Formatted date string or null if invalid
+ * Bare `YYYY-MM-DD` strings are parsed as midnight UTC by the `Date`
+ * constructor, which makes them render one day early in UTC- timezones. For
+ * those we build the date from local-time components instead. Well-shaped but
+ * invalid bare dates (e.g. "2026-13-45") are rejected rather than silently
+ * rolled forward by the constructor. Any other input falls back to the native
+ * `Date` constructor.
+ *
+ * This is the TypeScript-side parallel to `parseLocalDate()` in
+ * `lib/sharedUtils.js` (the OmniJS helper, which is not importable from TS),
+ * hardened to return `null` for unparseable input so callers can fail safely.
+ *
+ * @param dateString - ISO date string (YYYY-MM-DD or full ISO), or null/undefined
+ * @returns A local-time Date, or null if the input is missing or invalid
  */
-export function formatDateSafe(dateString: string | null | undefined): string | null {
+export function parseLocalDate(dateString: string | null | undefined): Date | null {
   if (!dateString) return null;
 
-  // Bare YYYY-MM-DD strings are parsed as UTC midnight by the Date constructor,
-  // which makes toLocaleDateString() display one day early in UTC- timezones.
-  // Use the local-time constructor for these so the displayed date stays correct.
   const bareDate = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString);
   if (bareDate) {
     const [, y, m, d] = bareDate.map(Number);
@@ -26,13 +33,54 @@ export function formatDateSafe(dateString: string | null | undefined): string | 
     if (date.getFullYear() !== y || date.getMonth() !== m - 1 || date.getDate() !== d) {
       return null;
     }
-    return date.toLocaleDateString();
+    return date;
   }
 
   const date = new Date(dateString);
-  if (isNaN(date.getTime())) {
-    return null;
-  }
+  return isNaN(date.getTime()) ? null : date;
+}
 
-  return date.toLocaleDateString();
+/**
+ * Safely formats a date string to locale date string.
+ * Returns null for invalid, null, or undefined date inputs.
+ *
+ * @param dateString - ISO date string, or null/undefined
+ * @returns Formatted date string or null if invalid
+ */
+export function formatDateSafe(dateString: string | null | undefined): string | null {
+  const date = parseLocalDate(dateString);
+  return date ? date.toLocaleDateString() : null;
+}
+
+/**
+ * Forecast bucket for a task's date relative to "now".
+ */
+export type ForecastDateCategory = 'OVERDUE' | 'TODAY' | 'TOMORROW' | 'FUTURE';
+
+/**
+ * Classify a forecast date key (bare `YYYY-MM-DD`) relative to a reference time.
+ *
+ * The key is parsed as local time (via {@link parseLocalDate}) so that "today"
+ * is judged against the viewer's local day, not UTC — otherwise a date due today
+ * would classify as OVERDUE for UTC- viewers. Returns null if the key cannot be
+ * parsed.
+ *
+ * @param dateString - Forecast date key in `YYYY-MM-DD` form
+ * @param now - Reference time (defaults to the current time)
+ * @returns The forecast category, or null if the key is invalid
+ */
+export function classifyForecastDate(
+  dateString: string,
+  now: Date = new Date()
+): ForecastDateCategory | null {
+  const date = parseLocalDate(dateString);
+  if (!date) return null;
+
+  const today = new Date(now);
+  today.setHours(0, 0, 0, 0);
+
+  if (date.getTime() === today.getTime()) return 'TODAY';
+  if (date.getTime() === today.getTime() + 24 * 60 * 60 * 1000) return 'TOMORROW';
+  if (date < today) return 'OVERDUE';
+  return 'FUTURE';
 }

--- a/src/utils/omnifocusScripts/lib/sharedUtils.js
+++ b/src/utils/omnifocusScripts/lib/sharedUtils.js
@@ -4,6 +4,13 @@
 /**
  * Parse date strings as local time.
  * Fixes issue where "2026-02-04" would be interpreted as midnight UTC.
+ *
+ * Twin of the hardened TypeScript `parseLocalDate()` in `src/utils/dateUtils.ts`.
+ * This OmniJS copy is intentionally separate (it is prepended into the OmniFocus
+ * runtime and is not importable from TS). Unlike the TS version it does NOT reject
+ * well-shaped-but-invalid dates (e.g. "2026-13-45" rolls forward) and would throw
+ * on null — #133 tracks hardening + testing this side. Keep the two in sync.
+ *
  * @param {string} dateStr - Date string in ISO format (YYYY-MM-DD or full ISO)
  * @returns {Date} - Date object in local timezone
  */

--- a/tests/dateUtils.test.mjs
+++ b/tests/dateUtils.test.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// Timezone-sensitive unit tests for the pure date helpers in src/utils/dateUtils.ts.
+//
+// These functions are pure but timezone-dependent: the bug they guard against
+// (a bare "YYYY-MM-DD" parsed as UTC midnight, then displayed one day early in
+// UTC- zones) is invisible to any UTC-based run, including CI. So every
+// timezone-relevant assertion is run under both a UTC- zone (America/Los_Angeles)
+// and a UTC+ zone (Australia/Sydney) and checks for *invariance* across them,
+// rather than pinning a locale-specific string (which would itself be the same
+// class of bug this suite exists to catch).
+//
+// Imports the compiled output, matching the other tests/*.mjs scripts.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseLocalDate,
+  formatDateSafe,
+  classifyForecastDate,
+} from '../dist/utils/dateUtils.js';
+
+const UTC_MINUS = 'America/Los_Angeles';
+const UTC_PLUS = 'Australia/Sydney';
+
+// Node re-reads TZ when process.env.TZ is assigned (tzset), so we can switch
+// zones within a single process. Restore the prior value afterwards.
+function withTZ(zone, fn) {
+  const prev = process.env.TZ;
+  process.env.TZ = zone;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env.TZ;
+    else process.env.TZ = prev;
+  }
+}
+
+test('classifyForecastDate: today key classifies as TODAY in both zones', () => {
+  for (const zone of [UTC_MINUS, UTC_PLUS]) {
+    withTZ(zone, () => {
+      // A fixed local "now" keeps this deterministic regardless of the wall clock.
+      const now = new Date(2026, 3, 28, 23, 30); // local 2026-04-28 23:30
+      assert.equal(classifyForecastDate('2026-04-28', now), 'TODAY', `zone=${zone}`);
+      assert.equal(classifyForecastDate('2026-04-27', now), 'OVERDUE', `zone=${zone}`);
+      assert.equal(classifyForecastDate('2026-04-29', now), 'TOMORROW', `zone=${zone}`);
+      assert.equal(classifyForecastDate('2026-05-10', now), 'FUTURE', `zone=${zone}`);
+    });
+  }
+});
+
+test('classifyForecastDate: malformed key returns null', () => {
+  assert.equal(classifyForecastDate('2026-13-45', new Date(2026, 3, 28)), null);
+});
+
+test('formatDateSafe: bare date renders the same day in both zones', () => {
+  const la = withTZ(UTC_MINUS, () => formatDateSafe('2026-04-28'));
+  const syd = withTZ(UTC_PLUS, () => formatDateSafe('2026-04-28'));
+
+  // Invariance: a bare date must display identically regardless of zone...
+  assert.equal(la, syd);
+  // ...and must be the 28th, not slipped back to the 27th.
+  assert.match(la, /\b28\b/);
+  assert.ok(!/\b27\b/.test(la), `unexpected day slip: ${la}`);
+});
+
+test('formatDateSafe: full ISO string still uses the general (fallback) path', () => {
+  const iso = '2026-04-28T07:30:00Z';
+  for (const zone of [UTC_MINUS, UTC_PLUS]) {
+    withTZ(zone, () => {
+      // Equality with a direct Date(iso) format proves the ISO input is NOT
+      // routed through the bare-date branch — the #114 fallback is preserved.
+      assert.equal(formatDateSafe(iso), new Date(iso).toLocaleDateString(), `zone=${zone}`);
+    });
+  }
+});
+
+test('formatDateSafe: malformed input returns null', () => {
+  assert.equal(formatDateSafe('2026-13-45'), null);
+  assert.equal(formatDateSafe(''), null);
+  assert.equal(formatDateSafe(null), null);
+  assert.equal(formatDateSafe(undefined), null);
+});
+
+test('parseLocalDate: bare date yields local midnight', () => {
+  const d = parseLocalDate('2026-04-28');
+  assert.ok(d instanceof Date);
+  assert.equal(d.getFullYear(), 2026);
+  assert.equal(d.getMonth(), 3); // April, zero-based
+  assert.equal(d.getDate(), 28);
+  assert.equal(d.getHours(), 0);
+  assert.equal(d.getMinutes(), 0);
+});
+
+test('parseLocalDate: full ISO string parses via Date constructor', () => {
+  const d = parseLocalDate('2026-04-28T07:30:00Z');
+  assert.ok(d instanceof Date);
+  assert.equal(d.getTime(), new Date('2026-04-28T07:30:00Z').getTime());
+});
+
+test('parseLocalDate: well-shaped but invalid dates return null', () => {
+  assert.equal(parseLocalDate('2026-13-45'), null); // month/day overflow
+  assert.equal(parseLocalDate('2026-02-30'), null); // Feb 30 rolls forward
+});
+
+test('parseLocalDate: falsy and unparseable input returns null', () => {
+  assert.equal(parseLocalDate(''), null);
+  assert.equal(parseLocalDate(null), null);
+  assert.equal(parseLocalDate(undefined), null);
+  assert.equal(parseLocalDate('not-a-date'), null);
+});

--- a/tests/dateUtils.test.mjs
+++ b/tests/dateUtils.test.mjs
@@ -9,7 +9,9 @@
 // rather than pinning a locale-specific string (which would itself be the same
 // class of bug this suite exists to catch).
 //
-// Imports the compiled output, matching the other tests/*.mjs scripts.
+// Run via `npm test` (alias for test:unit): esbuild bundles dateUtils.ts to
+// dist/test-build/dateUtils.mjs first, then node:test runs this file. Invoking
+// `node --test` on this file directly fails until that bundle exists.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -18,7 +20,7 @@ import {
   parseLocalDate,
   formatDateSafe,
   classifyForecastDate,
-} from '../dist/utils/dateUtils.js';
+} from '../dist/test-build/dateUtils.mjs';
 
 const UTC_MINUS = 'America/Los_Angeles';
 const UTC_PLUS = 'Australia/Sydney';
@@ -36,32 +38,41 @@ function withTZ(zone, fn) {
   }
 }
 
-test('classifyForecastDate: today key classifies as TODAY in both zones', () => {
+// classifyForecastDate takes a Date; forecast keys reach it via parseLocalDate
+// (which is the timezone-sensitive step). This mirrors how getForecastTasks calls it.
+const classifyKey = (key, now) => classifyForecastDate(parseLocalDate(key), now);
+
+test('classifyForecastDate: a date key lands in the right bucket in both zones', () => {
   for (const zone of [UTC_MINUS, UTC_PLUS]) {
     withTZ(zone, () => {
       // A fixed local "now" keeps this deterministic regardless of the wall clock.
       const now = new Date(2026, 3, 28, 23, 30); // local 2026-04-28 23:30
-      assert.equal(classifyForecastDate('2026-04-28', now), 'TODAY', `zone=${zone}`);
-      assert.equal(classifyForecastDate('2026-04-27', now), 'OVERDUE', `zone=${zone}`);
-      assert.equal(classifyForecastDate('2026-04-29', now), 'TOMORROW', `zone=${zone}`);
-      assert.equal(classifyForecastDate('2026-05-10', now), 'FUTURE', `zone=${zone}`);
+      assert.equal(classifyKey('2026-04-28', now), 'TODAY', `zone=${zone}`);
+      assert.equal(classifyKey('2026-04-27', now), 'OVERDUE', `zone=${zone}`);
+      assert.equal(classifyKey('2026-04-29', now), 'TOMORROW', `zone=${zone}`);
+      assert.equal(classifyKey('2026-05-10', now), 'FUTURE', `zone=${zone}`);
     });
   }
 });
 
-test('classifyForecastDate: malformed key returns null', () => {
-  assert.equal(classifyForecastDate('2026-13-45', new Date(2026, 3, 28)), null);
+test('classifyForecastDate: TOMORROW survives DST transitions (America/Los_Angeles)', () => {
+  withTZ(UTC_MINUS, () => {
+    // Spring forward: 2026-03-08 is a 23-hour local day, so next-midnight is +23h.
+    assert.equal(classifyKey('2026-03-09', new Date(2026, 2, 8, 12, 0)), 'TOMORROW', 'spring forward');
+    // Fall back: 2026-11-01 is a 25-hour local day, so next-midnight is +25h.
+    assert.equal(classifyKey('2026-11-02', new Date(2026, 10, 1, 12, 0)), 'TOMORROW', 'fall back');
+  });
 });
 
-test('formatDateSafe: bare date renders the same day in both zones', () => {
+test('formatDateSafe: bare date renders as local Apr 28 in both zones', () => {
+  // Locale-robust: compare against the locale's own rendering of local Apr 28,
+  // not a hard-coded "28", so the assertion holds under any locale/digit system.
+  const expected = withTZ(UTC_MINUS, () => new Date(2026, 3, 28).toLocaleDateString());
   const la = withTZ(UTC_MINUS, () => formatDateSafe('2026-04-28'));
   const syd = withTZ(UTC_PLUS, () => formatDateSafe('2026-04-28'));
 
-  // Invariance: a bare date must display identically regardless of zone...
-  assert.equal(la, syd);
-  // ...and must be the 28th, not slipped back to the 27th.
-  assert.match(la, /\b28\b/);
-  assert.ok(!/\b27\b/.test(la), `unexpected day slip: ${la}`);
+  assert.equal(la, syd);      // zone-invariant
+  assert.equal(la, expected); // local Apr 28, not slipped back to the 27th
 });
 
 test('formatDateSafe: full ISO string still uses the general (fallback) path', () => {
@@ -96,6 +107,14 @@ test('parseLocalDate: full ISO string parses via Date constructor', () => {
   const d = parseLocalDate('2026-04-28T07:30:00Z');
   assert.ok(d instanceof Date);
   assert.equal(d.getTime(), new Date('2026-04-28T07:30:00Z').getTime());
+});
+
+test('parseLocalDate: years 0-99 round-trip (no 1900s mapping)', () => {
+  const d = parseLocalDate('0099-01-01');
+  assert.ok(d instanceof Date);
+  assert.equal(d.getFullYear(), 99); // not 1999
+  assert.equal(d.getMonth(), 0);
+  assert.equal(d.getDate(), 1);
 });
 
 test('parseLocalDate: well-shaped but invalid dates return null', () => {


### PR DESCRIPTION
Follow-up to #114. Hardens the TypeScript-side date parsing, adds the repo's first automated test suite, and fixes a small DST display bug in the forecast.

## What

- New `parseLocalDate(dateString): Date | null` in `src/utils/dateUtils.ts` — the TS parallel to the OmniJS `parseLocalDate()` in `lib/sharedUtils.js`, hardened to return `null` for missing/invalid input and to round-trip years 0–99 (instead of mapping them to the 1900s).
- `formatDateSafe` now delegates to it (otherwise behaviour-preserving: bare `YYYY-MM-DD` → local midnight, full ISO → `new Date` fallback, invalid → `null`).
- Forecast `OVERDUE`/`TODAY`/`TOMORROW`/`FUTURE` bucketing extracted into a pure, total `classifyForecastDate(date: Date, now)`; `getForecastTasks` parses each key once via `parseLocalDate` and passes the `Date`.

## Behaviour fix (forecast)

`classifyForecastDate` now uses calendar arithmetic for "tomorrow" (`setDate(getDate()+1)`) instead of a fixed `+24h`. On the two DST-transition days a year the day after the change is again labelled `⏰ TOMORROW` rather than a plain weekday header — cosmetic (the date always rendered correctly). The forecast summary count also now reflects only the dates actually rendered.

## Tests

`tests/dateUtils.test.mjs` — 10 tests via Node's built-in `node:test` (no new dependencies). A `withTZ()` helper exercises the bare-date path under both `America/Los_Angeles` (UTC−) and `Australia/Sydney` (UTC+), asserting cross-zone **invariance** (and DST-transition correctness) rather than locale-specific strings. Coverage: bucket classification in both zones, DST-transition TOMORROW, bare-date rendering, full-ISO fallback preserved, malformed → `null`, years 0–99 round-trip.

Red-green verified: reverting the calendar arithmetic to `+24h` fails exactly the DST test.

## Test wiring

`npm test` runs the suite. It bundles the import-free `dateUtils.ts` with esbuild (`--bundle`) to `dist/test-build/dateUtils.mjs` — a separate path from the shipped `dist/utils/dateUtils.js`, so it's robust to a future import and doesn't pollute the real build. This matches the repo's `build:fast` escape hatch; the full `tsc` build OOMs under the lockfile-pinned TypeScript on Node 24 (filed separately as #136). Convention: `tests/*.test.mjs` = CI-safe unit tests, `tests/test-*.mjs` = manual OmniFocus integration.

## Verification

- `npm test` → 10/10 pass, exit 0.
- Full `tsc` type-check passes under TypeScript 5.6.3 (the devDep floor); the 5.9.3 OOM is environmental and tracked in #136.

Version: `1.32.2` — the correct single patch bump over `main` (`1.32.1`) for a release adding an internal helper plus a small bugfix. `docs/WHATS_NEW.md` and `CLAUDE.md` updated.

Closes #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
