### PR TITLE
feat(#126): build-provenance + staleness gate for get_server_version (v1.33.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,8 +824,12 @@ Use batch tools for multiple write operations:
 # Check MCP status
 claude mcp list
 
-# Verify server version
+# Verify server version (returns version + build provenance block)
 get_server_version
+# Response includes a `build` object: { commit, dirty, contentHash, buildStale }
+# buildStale: true  → running process predates the on-disk build; restart the server
+# To confirm you are also on the right source, compare build.commit with:
+#   git rev-parse --short HEAD   (buildStale alone only proves process = disk)
 
 # Test basic connection
 get_inbox_tasks
@@ -873,7 +877,7 @@ filter_tasks {
 - Verify Node.js 18+ is installed
 - Check Claude Code MCP configuration
 - Enable accessibility permissions for terminal apps if needed
-- Use `get_server_version` to verify the correct version is loaded after updates
+- Use `get_server_version` to verify the correct version is loaded after updates. The response now includes a `build` object (`commit`, `dirty`, `contentHash`, `buildStale`). `buildStale: true` means the running process predates the on-disk build — restart the server to clear it. Note that `buildStale: false` only proves the process matches the on-disk build; to confirm you are on the intended source, also compare `build.commit` against `git rev-parse --short HEAD`.
 
 ## 🎯 Use Cases
 

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -4,7 +4,7 @@
 
 ## v1.33.0 Build-staleness gate: `get_server_version` reports build provenance (#126)
 
-`get_server_version` now returns a `build` object alongside the version string: `commit` (short SHA baked in at build time), `dirty` (whether the working tree had uncommitted changes), `contentHash` (a hash of compiled output), and `buildStale` (true when the running process was launched from an older build than what is currently on disk).
+`get_server_version` now returns a `build` object alongside the version string: `commit` (short SHA baked in at build time), `dirty` (whether the working tree had uncommitted or untracked changes), `contentHash` (a hash of compiled output), and `buildStale` (true when the running process was launched from an older build than what is currently on disk).
 
 A matching version number is no longer sufficient evidence that the right code is running. `buildStale: true` signals that the server process predates the on-disk build and needs a restart. `buildStale: false` confirms the process matches the disk build, but you still need to compare `build.commit` against `git rev-parse --short HEAD` to confirm the disk build itself came from the intended source.
 

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,14 @@
-# OmniFocus MCP Server - What's New (v1.32.2)
+# OmniFocus MCP Server - What's New (v1.33.0)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.33.0 Build-staleness gate: `get_server_version` reports build provenance (#126)
+
+`get_server_version` now returns a `build` object alongside the version string: `commit` (short SHA baked in at build time), `dirty` (whether the working tree had uncommitted changes), `contentHash` (a hash of compiled output), and `buildStale` (true when the running process was launched from an older build than what is currently on disk).
+
+A matching version number is no longer sufficient evidence that the right code is running. `buildStale: true` signals that the server process predates the on-disk build and needs a restart. `buildStale: false` confirms the process matches the disk build, but you still need to compare `build.commit` against `git rev-parse --short HEAD` to confirm the disk build itself came from the intended source.
+
+---
 
 ## v1.32.2 Harden TS date parsing: shared `parseLocalDate` helper + timezone unit tests (#119)
 

--- a/docs/test-plans/issue-126-build-staleness-gate.md
+++ b/docs/test-plans/issue-126-build-staleness-gate.md
@@ -1,6 +1,6 @@
 # Smoke Test — Issue #126 (Build freshness gate for `get_server_version`)
 
-**Branch:** `emdash/feat-build-staleness-gate`
+**Branch:** `emdash/test-get-server-version-alone-sufficient-evidence-fresh-m80ic`
 **Version under test:** `1.33.0`
 **Tool affected:** `get_server_version` (returns `build.buildStale` and `build.commit` fields)
 **Run in:** a Claude Code (or other MCP client) session connected to **OmniFocus** on macOS.
@@ -13,7 +13,7 @@ Before this change, verifying that the running MCP server matched the intended c
 
 The fix is a three-layer build-freshness gate implemented via the `build` block returned by `get_server_version`, which now surfaces three independent checks:
 1. **Disk-behind-source**: detects uncommitted edits by comparing mtime of changed `src/*.ts` files against `dist/server.js`.
-2. **Wrong/old committed build**: detects branch mismatch by comparing `build.commit` (SHA from committed `dist/build-info.json`) against `git rev-parse --short HEAD`.
+2. **Wrong/old committed build**: detects branch mismatch by comparing `build.commit` (the short SHA the build records in `dist/build-info.json`, a gitignored artifact regenerated on every build) against `git rev-parse --short HEAD`.
 3. **Process-behind-disk**: detects a process that loaded an older build than what is now on disk by comparing `build.buildStale` against whether the running bundle hash matches the disk build.
 
 The three failure modes are operationally distinct—a single check misses categories of staleness. Only when all three pass can you trust that the running code is the intended code. The version number alone is informational; the `build` object's three fields are the real gate.
@@ -25,7 +25,7 @@ The three failure modes are operationally distinct—a single check misses categ
 1. **Build this branch** so the MCP server runs v1.33.0:
    ```bash
    cd /Users/mojen/dev/of-mcp
-   git checkout emdash/feat-build-staleness-gate
+   git checkout emdash/test-get-server-version-alone-sufficient-evidence-fresh-m80ic
    npm run build:fast
    ```
 2. **Point your MCP client at this build** (`dist/server.js` in this repo) and **restart the session** so it loads the new build. Schema changes live in the TypeScript layer, so a server restart is required — `.js` script hot-reload alone is not enough.

--- a/docs/test-plans/issue-126-build-staleness-gate.md
+++ b/docs/test-plans/issue-126-build-staleness-gate.md
@@ -1,0 +1,142 @@
+# Smoke Test — Issue #126 (Build freshness gate for `get_server_version`)
+
+**Branch:** `emdash/feat-build-staleness-gate`
+**Version under test:** `1.33.0`
+**Tool affected:** `get_server_version` (returns `build.buildStale` and `build.commit` fields)
+**Run in:** a Claude Code (or other MCP client) session connected to **OmniFocus** on macOS.
+
+---
+
+## What changed (context for the tester)
+
+Before this change, verifying that the running MCP server matched the intended code required manually confirming multiple layers: rebuilding after edits, committing changes, and restarting the client. A version number match to `package.json` was insufficient; the running code could be stale, the committed build could be from an older branch, or the process could have loaded a previous build. This made test results ambiguous.
+
+The fix is a three-layer build-freshness gate implemented via the `build` block returned by `get_server_version`, which now surfaces three independent checks:
+1. **Disk-behind-source**: detects uncommitted edits by comparing mtime of changed `src/*.ts` files against `dist/server.js`.
+2. **Wrong/old committed build**: detects branch mismatch by comparing `build.commit` (SHA from committed `dist/build-info.json`) against `git rev-parse --short HEAD`.
+3. **Process-behind-disk**: detects unstarted/restarted process by comparing `build.buildStale` against whether the running bundle hash matches the disk build.
+
+The three failure modes are operationally distinct—a single check misses categories of staleness. Only when all three pass can you trust that the running code is the intended code. The version number alone is informational; the `build` object's three fields are the real gate.
+
+---
+
+## Setup (do this once before the test cases)
+
+1. **Build this branch** so the MCP server runs v1.33.0:
+   ```bash
+   cd /Users/mojen/dev/of-mcp
+   git checkout emdash/feat-build-staleness-gate
+   npm run build
+   ```
+2. **Point your MCP client at this build** (`dist/server.js` in this repo) and **restart the session** so it loads the new build. Schema changes live in the TypeScript layer, so a server restart is required — `.js` script hot-reload alone is not enough.
+3. Have OmniFocus running with your normal database.
+
+### Build freshness gate
+
+After building and restarting, confirm the running code is fresh with these three complementary checks. The version number alone proves nothing about the running code, and the three failure modes are distinct, so all three checks are required:
+
+> **1. Disk-behind-source (did you rebuild after editing?).** For each `src/*.ts` you changed, confirm `dist/server.js` is newer:
+> ```bash
+> stat -f "%m %N" src/tools/definitions/editItem.ts dist/server.js   # substitute the file(s) you edited
+> ```
+> If any edited source is newer than `dist/server.js`, the build is stale on disk — run `npm run build:fast` before testing. (This is issue #126's fix #1; it is the only check that inspects source, and it catches uncommitted edits the `commit` check cannot.)
+>
+> **2. Wrong/old committed build (are you on the intended branch?).** Call `get_server_version` and confirm `build.commit` equals `git rev-parse --short HEAD` for the branch under test. A mismatch means you built/are testing the wrong (committed) state.
+>
+> **3. Process-behind-disk (did you restart after rebuilding?).** Confirm `build.buildStale === false`. `true` means your client is running a **process started before the latest build** (or mid-build) — restart it. `buildStale: false` only means "process matches disk," not "disk matches source" — checks 1 and 2 cover that.
+
+---
+
+## TC1 — Version gate (must pass before anything else)
+
+**Why:** confirms you're testing this branch's build, not an older one. However, version matching alone is not sufficient (see the Note at end of this plan).
+
+**Do:** ask Claude to run the `get_server_version` tool.
+
+**Expect:** the returned JSON has `"version": "1.33.0"`.
+
+- [ ] **PASS** — version is `1.33.0`
+- [ ] **FAIL** — any other version (stop; you're testing the wrong build — revisit Setup)
+
+---
+
+## TC2 — Build-loaded gate (the real freshness check)
+
+**Why:** on a freshly restarted client, both `build.commit` and `build.buildStale` must indicate that the running process matches the current branch's HEAD and the disk build. This is the operational gate; TC1 is merely informational.
+
+**Do:** after a fresh MCP client restart (following Setup's rebuild), call `get_server_version`.
+
+**Expect:**
+- `version` is `1.33.0` (same as TC1).
+- `build.commit` equals the output of `git rev-parse --short HEAD` on the current branch (if mismatch, the server is running a build from a different branch or commit).
+- `build.buildStale` is `false` (meaning the running process matches the disk build; `true` would mean restart is needed).
+- All three Build freshness gate checks above pass.
+
+**Pass criteria:** the running server provably matches both the current source and the current process state.
+
+- [ ] **PASS** — all three fields correct; Build freshness gate checks pass
+- [ ] **FAIL** — version mismatch, `build.commit` mismatch, `build.buildStale === true`, or freshness gate check fails (record output and which check failed)
+
+---
+
+## TC3 — Staleness detection (process-behind-disk detection)
+
+**Why:** confirms the `buildStale` flag detects when a process is running the old code after a rebuild—a common tester mistake.
+
+**Do:**
+1. Without restarting the client, edit a file in `src/*.ts` (e.g. add a comment to `src/tools/definitions/editItem.ts`).
+2. Run `npm run build:fast` to rebuild `dist/server.js`.
+3. Call `get_server_version` (the running client still has the old process).
+4. Verify `build.buildStale === true`.
+5. Restart the MCP client (reconnect the session).
+6. Call `get_server_version` again.
+7. Verify `build.buildStale === false`.
+
+**Expect:**
+- After step 3: `build.buildStale === true` (process is stale; running the old bundle).
+- After step 6: `build.buildStale === false` (restart fixed it; running matches disk now).
+
+**Pass criteria:** staleness is detected when the process is out-of-date, and cleared after a restart.
+
+- [ ] **PASS** — `buildStale` transitions `true` → `false` across restart
+- [ ] **FAIL** — `buildStale` stays `false` after rebuild (detection not working), or doesn't transition back to `false` after restart (record output)
+
+---
+
+## TC4 — Graceful degradation (missing build-info.json)
+
+**Why:** builds before issue #126's fix do not include `dist/build-info.json`. The tool should still return useful fields without crashing if `build-info.json` is absent or malformed.
+
+**Do:**
+1. (Optional: check out an older branch or manually delete `dist/build-info.json` to simulate a pre-126 build.)
+2. Call `get_server_version`.
+
+**Expect:**
+- `version` is still present (read from `package.json`).
+- `build.commit` is `"unknown"` (the file doesn't exist to provide it).
+- `build.buildStale` may be `null` (no saved hash to compare against) or still attempt to detect process-behind-disk from the bundle hash (either is acceptable graceful degradation).
+- No error is thrown; the tool returns the other fields without crashing.
+
+**Pass criteria:** missing or malformed build metadata does not break the tool.
+
+- [ ] **PASS** — tool returns gracefully; `version` is present; `build.commit === "unknown"`
+- [ ] **FAIL** — tool throws an error, or returns no `version`, or behaves unexpectedly (record output)
+
+---
+
+## Note
+
+The behaviour-asserting test case (TC2, TC3, and TC4 combined) is the real build-loaded gate. The version number (TC1) is informational only. A version match is necessary but not sufficient—as evidenced by TC3, the running code can report the correct version while still executing stale bytecode. Always run TC2's full freshness gate (including the three explicit checks) before interpreting test results as evidence of code correctness.
+
+---
+
+## Results
+
+| Test | Result | Notes |
+|------|--------|-------|
+| TC1 Version gate | ☐ PASS ☐ FAIL | `get_server_version` → version `1.33.0` |
+| TC2 Build-loaded gate | ☐ PASS ☐ FAIL | `build.commit` matches `git rev-parse --short HEAD`; `build.buildStale === false`; all three freshness gate checks pass |
+| TC3 Staleness detection | ☐ PASS ☐ FAIL | After rebuild (no restart): `build.buildStale === true`; after restart: `build.buildStale === false` |
+| TC4 Graceful degradation | ☐ PASS ☐ FAIL | Tool returns without error; `build.commit === "unknown"`; `version` still present |
+
+**Overall:** ☐ PASS ☐ FAIL

--- a/docs/test-plans/issue-126-build-staleness-gate.md
+++ b/docs/test-plans/issue-126-build-staleness-gate.md
@@ -14,7 +14,7 @@ Before this change, verifying that the running MCP server matched the intended c
 The fix is a three-layer build-freshness gate implemented via the `build` block returned by `get_server_version`, which now surfaces three independent checks:
 1. **Disk-behind-source**: detects uncommitted edits by comparing mtime of changed `src/*.ts` files against `dist/server.js`.
 2. **Wrong/old committed build**: detects branch mismatch by comparing `build.commit` (SHA from committed `dist/build-info.json`) against `git rev-parse --short HEAD`.
-3. **Process-behind-disk**: detects unstarted/restarted process by comparing `build.buildStale` against whether the running bundle hash matches the disk build.
+3. **Process-behind-disk**: detects a process that loaded an older build than what is now on disk by comparing `build.buildStale` against whether the running bundle hash matches the disk build.
 
 The three failure modes are operationally distinct—a single check misses categories of staleness. Only when all three pass can you trust that the running code is the intended code. The version number alone is informational; the `build` object's three fields are the real gate.
 
@@ -26,7 +26,7 @@ The three failure modes are operationally distinct—a single check misses categ
    ```bash
    cd /Users/mojen/dev/of-mcp
    git checkout emdash/feat-build-staleness-gate
-   npm run build
+   npm run build:fast
    ```
 2. **Point your MCP client at this build** (`dist/server.js` in this repo) and **restart the session** so it loads the new build. Schema changes live in the TypeScript layer, so a server restart is required — `.js` script hot-reload alone is not enough.
 3. Have OmniFocus running with your normal database.
@@ -72,7 +72,7 @@ After building and restarting, confirm the running code is fresh with these thre
 - `build.buildStale` is `false` (meaning the running process matches the disk build; `true` would mean restart is needed).
 - All three Build freshness gate checks above pass.
 
-**Pass criteria:** the running server provably matches both the current source and the current process state.
+**Pass criteria:** the running server provably matches the current committed build and the process loaded from disk — verified via all three freshness-gate checks, including the source mtime check.
 
 - [ ] **PASS** — all three fields correct; Build freshness gate checks pass
 - [ ] **FAIL** — version mismatch, `build.commit` mismatch, `build.buildStale === true`, or freshness gate check fails (record output and which check failed)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.32.2",
+  "version": "1.33.0",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "of-mcp": "./cli.cjs"
   },
   "scripts": {
-    "build": "tsc && npm run copy-files && chmod 755 dist/server.js",
-    "build:fast": "esbuild src/server.ts --bundle --platform=node --outfile=dist/server.js --format=esm --external:@modelcontextprotocol/sdk --external:zod && npm run copy-files && chmod 755 dist/server.js",
+    "build": "tsc && npm run copy-files && chmod 755 dist/server.js && node scripts/write-build-info.mjs",
+    "build:fast": "esbuild src/server.ts --bundle --platform=node --outfile=dist/server.js --format=esm --external:@modelcontextprotocol/sdk --external:zod && npm run copy-files && chmod 755 dist/server.js && node scripts/write-build-info.mjs",
     "copy-files": "mkdir -p dist/utils/omnifocusScripts/lib && cp src/utils/omnifocusScripts/*.js dist/utils/omnifocusScripts/ && cp src/utils/omnifocusScripts/lib/*.js dist/utils/omnifocusScripts/lib/",
     "start": "node dist/server.js",
     "dev": "tsc -w",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "tsc -w",
     "prepublishOnly": "npm run build",
     "test": "npm run test:unit",
-    "test:unit": "esbuild src/utils/dateUtils.ts --bundle --outfile=dist/test-build/dateUtils.mjs --format=esm --platform=node && node --test tests/*.test.mjs"
+    "test:unit": "esbuild src/utils/dateUtils.ts --bundle --outfile=dist/test-build/dateUtils.mjs --format=esm --platform=node && esbuild src/utils/buildInfo.ts --bundle --outfile=dist/test-build/buildInfo.mjs --format=esm --platform=node && node --test tests/*.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.8.0",

--- a/scripts/write-build-info.mjs
+++ b/scripts/write-build-info.mjs
@@ -3,7 +3,7 @@
 // report which build the running process loaded (issue #126). Run as a
 // post-compile step in `build` and `build:fast`.
 import { execFileSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -25,7 +25,7 @@ const commit = git(['rev-parse', '--short', 'HEAD']) ?? 'unknown';
 // dist/ is gitignored, so a rebuild never shows in `git status --porcelain`;
 // a non-empty status therefore means uncommitted source changes.
 const status = git(['status', '--porcelain']);
-const dirty = status === null ? null : status.trim().length > 0;
+const dirty = status === null ? null : status.length > 0;
 
 let contentHash = null;
 try {
@@ -35,5 +35,6 @@ try {
 }
 
 const buildInfo = { commit, dirty, contentHash };
+mkdirSync(distDir, { recursive: true });
 writeFileSync(join(distDir, 'build-info.json'), JSON.stringify(buildInfo, null, 2) + '\n');
 console.log(`write-build-info: dist/build-info.json (${commit}${dirty ? ', dirty' : ''})`);

--- a/scripts/write-build-info.mjs
+++ b/scripts/write-build-info.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Stamps dist/build-info.json with build provenance so get_server_version can
+// report which build the running process loaded (issue #126). Run as a
+// post-compile step in `build` and `build:fast`.
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const distDir = join(repoRoot, 'dist');
+const bundlePath = join(distDir, 'server.js');
+
+function git(args) {
+  try {
+    return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf-8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+const commit = git(['rev-parse', '--short', 'HEAD']) ?? 'unknown';
+
+// dist/ is gitignored, so a rebuild never shows in `git status --porcelain`;
+// a non-empty status therefore means uncommitted source changes.
+const status = git(['status', '--porcelain']);
+const dirty = status === null ? null : status.trim().length > 0;
+
+let contentHash = null;
+try {
+  contentHash = 'sha256-' + createHash('sha256').update(readFileSync(bundlePath)).digest('hex');
+} catch (err) {
+  console.warn(`write-build-info: could not hash ${bundlePath}: ${err.message}`);
+}
+
+const buildInfo = { commit, dirty, contentHash };
+writeFileSync(join(distDir, 'build-info.json'), JSON.stringify(buildInfo, null, 2) + '\n');
+console.log(`write-build-info: dist/build-info.json (${commit}${dirty ? ', dirty' : ''})`);

--- a/src/tools/definitions/getServerVersion.ts
+++ b/src/tools/definitions/getServerVersion.ts
@@ -4,6 +4,7 @@ import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/typ
 import { readFileSync, existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { getBuildBlock } from '../../utils/buildInfo.js';
 
 export const schema = z.object({});
 
@@ -31,7 +32,8 @@ export async function handler(_args: z.infer<typeof schema>, _extra: RequestHand
       version: packageJson.version,
       description: packageJson.description,
       nodeVersion: process.version,
-      platform: process.platform
+      platform: process.platform,
+      build: getBuildBlock()
     };
 
     return {

--- a/src/utils/buildInfo.ts
+++ b/src/utils/buildInfo.ts
@@ -50,14 +50,18 @@ function resolveRepoRoot(): string | null {
   // Mirrors getServerVersion's package.json resolution: works for the esbuild
   // bundle (dist/server.js -> ../package.json) and tsc output
   // (dist/utils/buildInfo.js -> ../../package.json).
-  const here = dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    join(here, '..', 'package.json'),
-    join(here, '..', '..', 'package.json'),
-    join(here, '..', '..', '..', 'package.json'),
-  ];
-  const found = candidates.find(p => existsSync(p));
-  return found ? dirname(found) : null;
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const candidates = [
+      join(here, '..', 'package.json'),
+      join(here, '..', '..', 'package.json'),
+      join(here, '..', '..', '..', 'package.json'),
+    ];
+    const found = candidates.find(p => existsSync(p));
+    return found ? dirname(found) : null;
+  } catch {
+    return null;
+  }
 }
 
 function hashBundle(repoRoot: string | null): string | null {

--- a/src/utils/buildInfo.ts
+++ b/src/utils/buildInfo.ts
@@ -1,0 +1,90 @@
+import { readFileSync, existsSync } from 'fs';
+import { createHash } from 'crypto';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+export interface BuildInfoRaw {
+  commit?: string;
+  dirty?: boolean | null;
+  contentHash?: string | null;
+}
+
+export interface BuildBlock {
+  commit: string;
+  dirty: boolean | null;
+  contentHash: string | null;
+  buildStale: boolean | null;
+}
+
+// --- pure helpers (unit-tested) ---
+
+export function computeBuildStale(
+  loadedHash: string | null,
+  currentHash: string | null,
+  stampHash: string | null
+): boolean | null {
+  if (loadedHash === null || currentHash === null) return null; // can't assess
+  if (loadedHash !== currentHash) return true;                  // process behind disk
+  if (stampHash !== null && stampHash !== loadedHash) return true; // started mid-build
+  return false;
+}
+
+export function shapeBuildBlock(args: {
+  raw: BuildInfoRaw | null;
+  loadedHash: string | null;
+  currentHash: string | null;
+}): BuildBlock {
+  const { raw, loadedHash, currentHash } = args;
+  const stampHash = raw?.contentHash ?? null;
+  return {
+    commit: raw?.commit ?? 'unknown',
+    dirty: raw?.dirty ?? null,
+    contentHash: stampHash,
+    buildStale: computeBuildStale(loadedHash, currentHash, stampHash),
+  };
+}
+
+// --- impure resolution + module-load capture ---
+
+function resolveRepoRoot(): string | null {
+  // Mirrors getServerVersion's package.json resolution: works for the esbuild
+  // bundle (dist/server.js -> ../package.json) and tsc output
+  // (dist/utils/buildInfo.js -> ../../package.json).
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(here, '..', 'package.json'),
+    join(here, '..', '..', 'package.json'),
+    join(here, '..', '..', '..', 'package.json'),
+  ];
+  const found = candidates.find(p => existsSync(p));
+  return found ? dirname(found) : null;
+}
+
+function hashBundle(repoRoot: string | null): string | null {
+  if (!repoRoot) return null;
+  try {
+    const buf = readFileSync(join(repoRoot, 'dist', 'server.js'));
+    return 'sha256-' + createHash('sha256').update(buf).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
+function readRaw(repoRoot: string | null): BuildInfoRaw | null {
+  if (!repoRoot) return null;
+  try {
+    return JSON.parse(readFileSync(join(repoRoot, 'dist', 'build-info.json'), 'utf-8')) as BuildInfoRaw;
+  } catch {
+    return null;
+  }
+}
+
+// Captured ONCE at module load === process start.
+const repoRoot = resolveRepoRoot();
+const loadedRaw = readRaw(repoRoot);
+const loadedHash = hashBundle(repoRoot);
+
+export function getBuildBlock(): BuildBlock {
+  const currentHash = hashBundle(repoRoot); // re-hash at call time
+  return shapeBuildBlock({ raw: loadedRaw, loadedHash, currentHash });
+}

--- a/tests/buildInfo.test.mjs
+++ b/tests/buildInfo.test.mjs
@@ -48,6 +48,17 @@ test('shapeBuildBlock: no stamp but bundle present still detects process-behind-
   assert.equal(block.buildStale, true);
 });
 
+test('shapeBuildBlock: stamp present with null contentHash + matching hashes -> fresh', () => {
+  const block = shapeBuildBlock({
+    raw: { commit: 'abc1234', dirty: false, contentHash: null },
+    loadedHash: 'sha256-aaa',
+    currentHash: 'sha256-aaa',
+  });
+  assert.deepEqual(block, {
+    commit: 'abc1234', dirty: false, contentHash: null, buildStale: false,
+  });
+});
+
 test('shapeBuildBlock: process behind disk is flagged stale', () => {
   const block = shapeBuildBlock({
     raw: { commit: 'abc1234', dirty: true, contentHash: 'sha256-aaa' },

--- a/tests/buildInfo.test.mjs
+++ b/tests/buildInfo.test.mjs
@@ -1,0 +1,59 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeBuildStale, shapeBuildBlock } from '../dist/test-build/buildInfo.mjs';
+
+test('computeBuildStale: process matches disk and stamp -> fresh', () => {
+  assert.equal(computeBuildStale('sha256-aaa', 'sha256-aaa', 'sha256-aaa'), false);
+});
+
+test('computeBuildStale: process behind disk -> stale', () => {
+  assert.equal(computeBuildStale('sha256-aaa', 'sha256-bbb', 'sha256-aaa'), true);
+});
+
+test('computeBuildStale: loaded mid-build (stamp != loaded bundle) -> stale', () => {
+  // bundle written (new) but stamp still describes the previous build
+  assert.equal(computeBuildStale('sha256-new', 'sha256-new', 'sha256-old'), true);
+});
+
+test('computeBuildStale: a null loaded/current hash means unknown', () => {
+  assert.equal(computeBuildStale(null, 'sha256-bbb', 'sha256-bbb'), null);
+  assert.equal(computeBuildStale('sha256-aaa', null, 'sha256-aaa'), null);
+});
+
+test('computeBuildStale: a missing stamp does not by itself mean stale', () => {
+  assert.equal(computeBuildStale('sha256-aaa', 'sha256-aaa', null), false);
+});
+
+test('shapeBuildBlock: full raw + matching hashes -> fresh', () => {
+  const block = shapeBuildBlock({
+    raw: { commit: 'abc1234', dirty: false, contentHash: 'sha256-aaa' },
+    loadedHash: 'sha256-aaa',
+    currentHash: 'sha256-aaa',
+  });
+  assert.deepEqual(block, {
+    commit: 'abc1234', dirty: false, contentHash: 'sha256-aaa', buildStale: false,
+  });
+});
+
+test('shapeBuildBlock: missing build-info falls back to unknown/null', () => {
+  const block = shapeBuildBlock({ raw: null, loadedHash: null, currentHash: null });
+  assert.deepEqual(block, {
+    commit: 'unknown', dirty: null, contentHash: null, buildStale: null,
+  });
+});
+
+test('shapeBuildBlock: no stamp but bundle present still detects process-behind-disk', () => {
+  const block = shapeBuildBlock({ raw: null, loadedHash: 'sha256-aaa', currentHash: 'sha256-bbb' });
+  assert.equal(block.commit, 'unknown');
+  assert.equal(block.buildStale, true);
+});
+
+test('shapeBuildBlock: process behind disk is flagged stale', () => {
+  const block = shapeBuildBlock({
+    raw: { commit: 'abc1234', dirty: true, contentHash: 'sha256-aaa' },
+    loadedHash: 'sha256-aaa',
+    currentHash: 'sha256-bbb',
+  });
+  assert.equal(block.buildStale, true);
+  assert.equal(block.dirty, true);
+});


### PR DESCRIPTION
## Summary

Makes `get_server_version` report the identity of the build the running process actually loaded, so a matching version number can no longer hide stale compiled code (issue #126).

- **New `src/utils/buildInfo.ts`** — pure `computeBuildStale`/`shapeBuildBlock` helpers + a module-load capture of the bundle hash and build stamp; `getBuildBlock()` re-hashes `dist/server.js` at call time.
- **New `scripts/write-build-info.mjs`** — post-compile step stamping `dist/build-info.json` `{commit, dirty, contentHash}`; wired into both `build` and `build:fast`.
- **`get_server_version`** now returns a `build` block: `commit`, `dirty`, `contentHash`, `buildStale`.
- `buildStale: true` ⇒ the running process predates the on-disk build (or started mid-build) — restart. It only proves process-vs-disk; confirming you're on the intended source also needs `build.commit` vs `git rev-parse --short HEAD`, plus an mtime check of edited `src/*.ts` vs `dist/server.js`.
- **Reusable "Build freshness gate" smoke plan** — `docs/test-plans/issue-126-build-staleness-gate.md`.
- Version `1.32.2 → 1.33.0`; README + `docs/WHATS_NEW.md` updated.

## Notes

- `dist/` is gitignored, so `dist/build-info.json` is generated by the build and never committed.
- `build:fast` (esbuild, single bundle) is the supported path where the hash is exact; under per-file `tsc` a change that doesn't touch `src/server.ts` can leave `dist/server.js` byte-identical (documented limitation). `tsc`/`npm run build` also OOMs on Node 24 (#136).

## Testing

- `npm test` → **20/20 pass**, pristine output.
- Build-staleness flip verified **headlessly against the real handler** (`get_server_version` is pure Node — no OmniFocus / MCP-wire dependency): fresh build → `buildStale:false` (commit = HEAD); disk rebuilt under a running process → `true`; fresh process (restart) → `false`; missing `build-info.json` → `commit:"unknown"`, no crash. All four test cases pass.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)