### PR TITLE
chore(#126): correct stale 'source changes' comment in write-build-info

### DIFF
--- a/scripts/write-build-info.mjs
+++ b/scripts/write-build-info.mjs
@@ -23,7 +23,7 @@ function git(args) {
 const commit = git(['rev-parse', '--short', 'HEAD']) ?? 'unknown';
 
 // dist/ is gitignored, so a rebuild never shows in `git status --porcelain`;
-// a non-empty status therefore means uncommitted source changes.
+// a non-empty status therefore means uncommitted or untracked changes.
 const status = git(['status', '--porcelain']);
 const dirty = status === null ? null : status.length > 0;
 


### PR DESCRIPTION
Post-merge follow-up to #138 (Minor review nit #1).

The `dirty` comment in `scripts/write-build-info.mjs` still said a non-empty `git status --porcelain` "means uncommitted **source** changes". Porcelain also lists **untracked** files, so it really means uncommitted *or untracked* changes — which is exactly the wording already shipped in `docs/WHATS_NEW.md` for v1.33.0. This aligns the internal comment with the shipped doc.

Comment-only; no behaviour change (`dirty` was always computed from porcelain length).

🤖 Generated with [Claude Code](https://claude.com/claude-code)